### PR TITLE
[파즈 조][파즈]1장 2주차 PR 제출합니다. 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,8 @@ repositories {
 
 dependencies {
     implementation group: 'mysql', name: 'mysql-connector-java', version: '8.0.24'
+    implementation group: 'org.springframework', name: 'spring-core', version: '3.2.18.RELEASE'
+    implementation group: 'org.springframework', name: 'spring-context', version: '3.1.4.RELEASE'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -11,8 +11,7 @@ repositories {
 
 dependencies {
     implementation group: 'mysql', name: 'mysql-connector-java', version: '8.0.24'
-    implementation group: 'org.springframework', name: 'spring-core', version: '3.2.18.RELEASE'
-    implementation group: 'org.springframework', name: 'spring-context', version: '3.1.4.RELEASE'
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: '2.4.4'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ repositories {
 }
 
 dependencies {
+    implementation group: 'org.springframework', name: 'spring-jdbc', version: '5.3.5'
     implementation group: 'mysql', name: 'mysql-connector-java', version: '8.0.24'
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: '2.4.4'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'

--- a/src/main/java/Application.java
+++ b/src/main/java/Application.java
@@ -6,21 +6,21 @@ import java.sql.SQLException;
 
 public class Application {
     public static void main(String[] args) throws ClassNotFoundException, SQLException {
-        UserDao dao = new UserDao(new DConnectionMaker());
-
-        User user = new User();
-        user.setId("bepoz");
-        user.setName("강승윤");
-        user.setPassword("positive");
-
-        dao.add(user);
-
-        System.out.println(user.getId() + " 등록 성공");
-
-        User user2 = dao.get(user.getId());
-        System.out.println(user2.getName());
-        System.out.println(user2.getPassword());
-
-        System.out.println(user2.getId() + " 조회 성공");
+//        UserDao dao = new UserDao(new DConnectionMaker());
+//
+//        User user = new User();
+//        user.setId("bepoz");
+//        user.setName("강승윤");
+//        user.setPassword("positive");
+//
+//        dao.add(user);
+//
+//        System.out.println(user.getId() + " 등록 성공");
+//
+//        User user2 = dao.get(user.getId());
+//        System.out.println(user2.getName());
+//        System.out.println(user2.getPassword());
+//
+//        System.out.println(user2.getId() + " 조회 성공");
     }
 }

--- a/src/main/java/Application.java
+++ b/src/main/java/Application.java
@@ -1,0 +1,26 @@
+import dao.DConnectionMaker;
+import dao.UserDao;
+import domain.User;
+
+import java.sql.SQLException;
+
+public class Application {
+    public static void main(String[] args) throws ClassNotFoundException, SQLException {
+        UserDao dao = new UserDao(new DConnectionMaker());
+
+        User user = new User();
+        user.setId("bepoz");
+        user.setName("강승윤");
+        user.setPassword("positive");
+
+        dao.add(user);
+
+        System.out.println(user.getId() + " 등록 성공");
+
+        User user2 = dao.get(user.getId());
+        System.out.println(user2.getName());
+        System.out.println(user2.getPassword());
+
+        System.out.println(user2.getId() + " 조회 성공");
+    }
+}

--- a/src/main/java/dao/ConnectionMaker.java
+++ b/src/main/java/dao/ConnectionMaker.java
@@ -1,0 +1,8 @@
+package dao;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+public interface ConnectionMaker {
+    Connection makeConnection() throws ClassNotFoundException, SQLException;
+}

--- a/src/main/java/dao/CountingConnectionMaker.java
+++ b/src/main/java/dao/CountingConnectionMaker.java
@@ -1,0 +1,22 @@
+package dao;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+public class CountingConnectionMaker implements ConnectionMaker{
+    private int counter =0 ;
+    private ConnectionMaker realConnectionMaker;
+
+    public CountingConnectionMaker(ConnectionMaker realConnectionMaker) {
+        this.realConnectionMaker = realConnectionMaker;
+    }
+
+    public Connection makeConnection() throws ClassNotFoundException, SQLException {
+        this.counter++;
+        return realConnectionMaker.makeConnection();
+    }
+
+    public int getCounter() {
+        return this.counter;
+    }
+}

--- a/src/main/java/dao/CountingDaoFactory.java
+++ b/src/main/java/dao/CountingDaoFactory.java
@@ -1,0 +1,22 @@
+package dao;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class CountingDaoFactory {
+    @Bean
+    public UserDao userDao() {
+        return new UserDao(connectionMaker());
+    }
+
+    @Bean
+    public ConnectionMaker connectionMaker() {
+        return new CountingConnectionMaker(realConnectionMaker());
+    }
+
+    @Bean
+    public ConnectionMaker realConnectionMaker() {
+        return new DConnectionMaker();
+    }
+}

--- a/src/main/java/dao/CountingDaoFactory.java
+++ b/src/main/java/dao/CountingDaoFactory.java
@@ -2,12 +2,26 @@ package dao;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.datasource.SimpleDriverDataSource;
+
+import javax.sql.DataSource;
 
 @Configuration
 public class CountingDaoFactory {
     @Bean
     public UserDao userDao() {
-        return new UserDao(connectionMaker());
+        return new UserDao(dataSource());
+    }
+
+    @Bean
+    public DataSource dataSource() {
+        SimpleDriverDataSource dataSource = new SimpleDriverDataSource();
+        dataSource.setDriverClass(com.mysql.cj.jdbc.Driver.class);
+        dataSource.setUrl("jdbc:mysql://localhost:13306/db_name?serverTimezone=UTC&characterEncoding=UTF-8");
+        dataSource.setUsername("root");
+        dataSource.setPassword("root");
+
+        return dataSource;
     }
 
     @Bean

--- a/src/main/java/dao/DConnectionMaker.java
+++ b/src/main/java/dao/DConnectionMaker.java
@@ -1,0 +1,17 @@
+package dao;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+public class DConnectionMaker implements ConnectionMaker {
+
+    @Override
+    public Connection makeConnection() throws ClassNotFoundException, SQLException {
+        Class.forName("com.mysql.cj.jdbc.Driver");
+        return DriverManager.getConnection(
+                "jdbc:mysql://localhost:13306/db_name?serverTimezone=UTC&characterEncoding=UTF-8",
+                "root", "root"
+        );
+    }
+}

--- a/src/main/java/dao/DaoFactory.java
+++ b/src/main/java/dao/DaoFactory.java
@@ -2,13 +2,28 @@ package dao;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.datasource.SimpleDriverDataSource;
+
+import javax.sql.DataSource;
+import java.sql.DriverManager;
 
 @Configuration
 public class DaoFactory {
 
     @Bean
+    public DataSource dataSource() {
+        SimpleDriverDataSource dataSource = new SimpleDriverDataSource();
+        dataSource.setDriverClass(com.mysql.cj.jdbc.Driver.class);
+        dataSource.setUrl("jdbc:mysql://localhost:13306/db_name?serverTimezone=UTC&characterEncoding=UTF-8");
+        dataSource.setUsername("root");
+        dataSource.setPassword("root");
+
+        return dataSource;
+    }
+
+    @Bean
     public UserDao userDao() {
-        return new UserDao(connectionMaker());
+        return new UserDao(dataSource());
     }
 
     @Bean

--- a/src/main/java/dao/DaoFactory.java
+++ b/src/main/java/dao/DaoFactory.java
@@ -1,11 +1,18 @@
 package dao;
 
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
 public class DaoFactory {
+
+    @Bean
     public UserDao userDao() {
         return new UserDao(connectionMaker());
     }
 
-    private ConnectionMaker connectionMaker() {
+    @Bean
+    public ConnectionMaker connectionMaker() {
         return new DConnectionMaker();
     }
 }

--- a/src/main/java/dao/DaoFactory.java
+++ b/src/main/java/dao/DaoFactory.java
@@ -1,0 +1,19 @@
+package dao;
+
+public class DaoFactory {
+    public UserDao userDao() {
+        return new UserDao(connectionMaker());
+    }
+
+    public AccountDao accountDao() {
+        return new AccountDao(connectionMaker());
+    }
+
+    public MessageDao messageDao() {
+        return new MessageDao(connectionMaker());
+    }
+
+    private ConnectionMaker connectionMaker() {
+        return new DConnectionMaker();
+    }
+}

--- a/src/main/java/dao/DaoFactory.java
+++ b/src/main/java/dao/DaoFactory.java
@@ -5,14 +5,6 @@ public class DaoFactory {
         return new UserDao(connectionMaker());
     }
 
-    public AccountDao accountDao() {
-        return new AccountDao(connectionMaker());
-    }
-
-    public MessageDao messageDao() {
-        return new MessageDao(connectionMaker());
-    }
-
     private ConnectionMaker connectionMaker() {
         return new DConnectionMaker();
     }

--- a/src/main/java/dao/NConnectionMaker.java
+++ b/src/main/java/dao/NConnectionMaker.java
@@ -1,0 +1,16 @@
+package dao;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+public class NConnectionMaker implements ConnectionMaker{
+    @Override
+    public Connection makeConnection() throws ClassNotFoundException, SQLException {
+        Class.forName("com.mysql.cj.jdbc.Driver");
+        return DriverManager.getConnection(
+                "jdbc:mysql://localhost:13306/db_name?serverTimezone=UTC&characterEncoding=UTF-8",
+                "root", "root"
+        );
+    }
+}

--- a/src/main/java/dao/SimpleConnectionMaker.java
+++ b/src/main/java/dao/SimpleConnectionMaker.java
@@ -1,0 +1,15 @@
+package dao;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+public class SimpleConnectionMaker {
+    public Connection makeNewConnection() throws ClassNotFoundException, SQLException {
+        Class.forName("com.mysql.cj.jdbc.Driver");
+        return DriverManager.getConnection(
+                "jdbc:mysql://localhost:13306/db_name?serverTimezone=UTC&characterEncoding=UTF-8",
+                "root", "root"
+        );
+    }
+}

--- a/src/main/java/dao/UserDao.java
+++ b/src/main/java/dao/UserDao.java
@@ -2,17 +2,18 @@ package dao;
 
 import domain.User;
 
+import javax.sql.DataSource;
 import java.sql.*;
 
 public class UserDao {
-    private ConnectionMaker connectionMaker;
+    private DataSource dataSource;
 
-    public UserDao(ConnectionMaker connectionMaker) {
-        this.connectionMaker = connectionMaker;
+    public UserDao(DataSource dataSource) {
+        this.dataSource = dataSource;
     }
 
     public void add(User user) throws ClassNotFoundException, SQLException {
-        Connection c = connectionMaker.makeConnection();
+        Connection c = dataSource.getConnection();
 
         PreparedStatement ps = c.prepareStatement(
                 "insert into users(id, name, password) values(?, ?, ?)"
@@ -27,7 +28,7 @@ public class UserDao {
     }
 
     public User get(String id) throws ClassNotFoundException, SQLException {
-        Connection c = connectionMaker.makeConnection();
+        Connection c = dataSource.getConnection();
 
         PreparedStatement ps = c.prepareStatement(
                 "select * from users where id = ?"

--- a/src/main/java/dao/UserDao.java
+++ b/src/main/java/dao/UserDao.java
@@ -1,0 +1,50 @@
+package dao;
+
+import domain.User;
+
+import java.sql.*;
+
+public class UserDao {
+    private ConnectionMaker connectionMaker;
+
+    public UserDao(ConnectionMaker connectionMaker) {
+        this.connectionMaker = connectionMaker;
+    }
+
+    public void add(User user) throws ClassNotFoundException, SQLException {
+        Connection c = connectionMaker.makeConnection();
+
+        PreparedStatement ps = c.prepareStatement(
+                "insert into users(id, name, password) values(?, ?, ?)"
+        );
+        ps.setString(1, user.getId());
+        ps.setString(2, user.getName());
+        ps.setString(3, user.getPassword());
+
+        ps.executeUpdate();
+        ps.close();
+        c.close();
+    }
+
+    public User get(String id) throws ClassNotFoundException, SQLException {
+        Connection c = connectionMaker.makeConnection();
+
+        PreparedStatement ps = c.prepareStatement(
+                "select * from users where id = ?"
+        );
+        ps.setString(1, id);
+
+        ResultSet rs = ps.executeQuery();
+        rs.next();
+        User user = new User();
+        user.setId(rs.getString("id"));
+        user.setName(rs.getString("name"));
+        user.setPassword(rs.getString("password"));
+
+        rs.close();
+        ps.close();
+        c.close();
+
+        return user;
+    }
+}

--- a/src/main/java/dao/UserDaoConnectionCountingTest.java
+++ b/src/main/java/dao/UserDaoConnectionCountingTest.java
@@ -1,0 +1,24 @@
+package dao;
+
+import domain.User;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import java.sql.SQLException;
+
+public class UserDaoConnectionCountingTest {
+    public static void main(String[] args) throws ClassNotFoundException, SQLException {
+        ApplicationContext context = new AnnotationConfigApplicationContext(CountingDaoFactory.class);
+        UserDao userDao = context.getBean("userDao", UserDao.class);
+
+        User user = new User();
+        user.setId("bepoz");
+        user.setName("강승윤");
+        user.setPassword("positive");
+
+        userDao.add(user);
+
+        CountingConnectionMaker ccm = context.getBean("connectionMaker", CountingConnectionMaker.class);
+        System.out.println("Connection counter: " + ccm.getCounter());
+    }
+}

--- a/src/main/java/dao/UserDaoTest.java
+++ b/src/main/java/dao/UserDaoTest.java
@@ -1,0 +1,26 @@
+package dao;
+
+import domain.User;
+
+import java.sql.SQLException;
+
+public class UserDaoTest {
+    public static void main(String[] args) throws SQLException, ClassNotFoundException {
+        UserDao dao = new DaoFactory().userDao();
+
+        User user = new User();
+        user.setId("bepoz");
+        user.setName("강승윤");
+        user.setPassword("positive");
+
+        dao.add(user);
+
+        System.out.println(user.getId() + " 등록 성공");
+
+        User user2 = dao.get(user.getId());
+        System.out.println(user2.getName());
+        System.out.println(user2.getPassword());
+
+        System.out.println(user2.getId() + " 조회 성공");
+    }
+}

--- a/src/main/java/dao/UserDaoTest.java
+++ b/src/main/java/dao/UserDaoTest.java
@@ -1,12 +1,15 @@
 package dao;
 
 import domain.User;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 import java.sql.SQLException;
 
 public class UserDaoTest {
     public static void main(String[] args) throws SQLException, ClassNotFoundException {
-        UserDao dao = new DaoFactory().userDao();
+        ApplicationContext context = new AnnotationConfigApplicationContext(DaoFactory.class);
+        UserDao dao = context.getBean("userDao", UserDao.class);
 
         User user = new User();
         user.setId("bepoz");

--- a/src/main/java/domain/User.java
+++ b/src/main/java/domain/User.java
@@ -1,0 +1,31 @@
+package domain;
+
+public class User {
+    String id;
+    String name;
+    String password;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}


### PR DESCRIPTION
이번 주차 내용은 브라운이 제공했던 학습테스트 마지막인 Spring Configuration 부분의 내용이어서 더 흥미롭게 볼 수 있었던 것 같습니다.  
학습로그 정리라기엔 좀 그렇고... 공부하면서 중심내용들을 그냥 적어보면서 진행했습니다. 이번주도 화이팅입니다!!
<br/>  
* 스프링에서는 스프링이 제어권을 가지고 직접 만들고 관계를 부여하는 오브젝트를 **빈**이라고 부른다.  

* 스프링 빈은 스프링 컨테이너가 생성과 관계설정, 사용 등을 제어해주는 제어의 역전이 적용된 오브젝트를 가리키는 말이다. 

* 스프링에서는 빈의 생성과 관계설정 같은 제어를 담당하는 IoC 오브젝트를 **빈 팩토리**라고 부른다. 보통 빈 팩토리보다는 이를 좀 더 확장한 애플리케이션 컨텍스트를 주로 사용한다. 

* 애플리케이션 컨텍스트는 IoC 방식을 따라 만들어진 일종의 빈 팩토리이며, 빈 팩토리라고 말할 때는 빈을 생성하고 관계를 설정하는 IoC의 기본 기능에 초점을 맞춘 것이고, 애플리케이션 컨텍스트라고 말할 때는 애플리케이션 전반에 걸쳐 모든 구성요소의 제어 작업을 담당하는 IoC 엔진이라는 의미가 좀 더 부각된다.

* ``@Configuration`` : 애플리케이션 컨텍스트 또는 빈 팩토리가 사용할 설정정보라는 표시

* ``@Bean`` : 오브젝트 생성을 담당하는 IoC용 메서드라는 표시

* ``new AnnotationConfigApplicationContext(가져올 클래스)``을 통해 어플리케이션 컨텍스트를 만든다. 생성된 컨텍스트에 ``getBean(컨텍스트에 등록된 빈 이름, 타입)``을 통해 등록된 빈을 가져올 수가 있다. ``getBean``은 기본적으로 Object 타입으로 리턴하게 되어 있어서 매번 캐스팅을 해주어야 했지만, 두 번째 파라미터에 리턴 타입을 주면 캐스팅 코드를 사용하지 않아도 된다. 

* 스프링에서 애플리케이션 컨텍스트를 Ioc 컨테이너라 하기도 하고, 스프링 컨테이너라고 부르기도 한다. 또는 빈 팩토리라고 부를 수도 있다. 애플리케이션 컨텍스트는 ApplicationContext 인터페이스를 구현하는데, ApplicationContext는 빈 팩토리가 구현하는 BeanFactory 인터페이스를 상속했으므로 애플리케이션 컨텍스트는 일종의 빈 팩토리라고 볼 수 있다. 

* DaoFactory가 UserDao를 비롯한 DAO 오브젝트를 생성하고 DB 생성 오브젝트와 관계를 맺어주는 제한적인 역할을 하는 데 반해, 어플리케이션 컨텍스트는 어플리케이션에서 IoC를 적용해서 관리할 모든 오브젝트에 대한 생성과 관계설정을 담당한다.대신 ApplicationContext에는 DaoFactory와 달리 직접 오브젝트를 생성하고 관계를 맺어주는 코드가 없고, 그런 생성정보와 연관관계 정보를 별도의 설정정보를 통해 얻는다.

* ``@Configuration``이 붙은 DaoFactory는 이 어플리케이션 컨텍스트가 활용하는 IoC 설정정보다. 

* 오브젝트 팩토리에서 사용했던 IoC 원리를 그대로 적용하는 데 어플리케이션 컨텍스트를 사용하는 이유는 범용적이고 유연한 방법으로 IoC 기능을 확장하기 위해서다. 얻을 수 있는 장점은 다음과 같다.

  * 클라이언트는 구체적인 팩토리 클래스를 알 필요가 없다
  * 애플리케이션 컨텍스트는 종합적인 IoC 서비스를 제공해준다.
  * 어플리케이션 컨텍스트는 빈을 검색하는 다양한 방법을 제공한다.

* 용어 정리

  * 빈 : 스프링이 IoC 방식으로 관리하는 오브젝트. 애플리케이션에서 만들어지는 모든 오브젝트가 다 빈은 아니고, 그중에서 스프링이 직접 그 생성과 제어를 담당하는 오브젝트만을 빈이라고 부른다.
  * 빈 팩토리 : 스프링의 IoC를 담당하는 핵심 컨테이너. 빈 등록,생성,조회,반환, 그 외에 관리하는 기능을 담당한다. 보통 빈 팩토리를 바로 사용하지 않고 이를 확장한 어플리케이션 컨텍스트를 이용한다.
  * 어플리케이션 컨텍스트 : 빈 팩토리를 확장한 IoC 컨테이너. 빈 팩토리라고 부를 때는 주로 빈의 생성과 제어의 관점에서 이야기하는 것이고, 어플리케이션 컨텍스트라고 할 때는 스프링이 제공하는 어플리케이션 지원 기능을 모두 포함해서 이야기하는 것이다.
  * 설정정보/설정 메타정보 : 어플리케이션 컨텍스트 또는 빈 팩토리가 IoC를 적용하기 위해 사용하는 메타정보.
  * 컨테이너 또는 IoC 컨테이너 : IoC 방식으로 빈을 관리한다는 의미에서 어플리케이션 컨텍스트나 빈 팩토리를 컨테이너 또는 IoC 컨테이너라고도 한다.
  * 스프링 프레임워크 : IoC 컨테이너, 어플리케이션 컨텍스트를 포함해서 스프링이 제공하는 모든 기능을 통틀어 말할 때 주로 사용한다. 그냥 스프링이라고 줄여서 말하기도 한다.

* 어플리케이션 컨텍스트는 싱글톤을 저장하고 관리하는 **싱글톤 레지스트리** 이기도 하다. 스프링은 기본적으로 별다른 설정을 하지 않으면 내부에서 생성하는 빈 오브젝트를 모두 싱글톤으로 만든다. (싱글톤이 아니라면 생성되는 인스턴스가 어마어마하기 때문에 서버가 감당하기 힘듬)

* 싱글톤의 단점은 다음과 같다.

  * 상속할 수 없다.
  * 테스트하기가 힘들다.
  * 서버환경에서는 싱글톤이 하나만 만들어지는 것을 보장하지 못한다.
  * 싱글톤의 사용은 전역 상태를 만들 수 있기 때문에 바람직하지 못하다.

* 싱글톤 레지스트리의 장점은 스태틱 메소드와 private 생성자를 사용해야 하는 비정상적인 클래스가 아니라 평범한 자바 클래스를 싱글톤으로 활용하게 해준다는 점이다. 평범한 자바 클래스라도 IoC 방식의 컨테이너를 사용해서 생성과 관계설정, 사용 등에 대한 제어권을 컨테이너에게 넘기면 손쉽게 싱글톤 방식으로 만들어져 관리되게 할 수 있다. 오브젝트 생성에 관한 모든 권한은 IoC 기능을 제공하는 어플리케이션 컨텍스트에게 있기 때문이다.

* public 생성자를 가질 수 있고, 테스트를 위한 mock 오브젝트로 대체도 가능하고, 생성자 파라미터를 이용해서 사용할 오브젝트를 넣어주게 할 수도 있다. 

* 싱글톤으로 진행하기 위해서는 멀티스레드 환경을 주의해야 한다. 따라서, 상태정보를 내부에 갖고 있지 않은 무상태 방식으로 만들어져야 한다.  
  하지만, 읽기전용의 정보라면 싱글톤에서 인스턴스 변수로 사용해도 좋다.

* IoC 컨테이너라고 불리던 스프링이 지금은 의존관계 주입 컨테이너 또는 그 영문약자를 써서 DI 컨테이너라고 더 많이 불리고 있다.

* 의존한다는 건 형식이 바뀌거나 하면 그 영향이 전달되는 것이다. 

* UserDao는 ConnectionMaker에 의존하고 있다. ConnectionMaker 인터페이스가 변한다면 그 영향을 직접적으로 받게 된다. 하지만 ConnectionMaker 인터페이스를 구현한 클래스, 즉 DConnectionMaker 등이 다른 것으로 바뀌거나 그 내부에서 사용하는 메소드에 변화가 생겨도 UserDao에 영향을 주지 않는다. 이렇게 인터페이스에 대해서만 의존관계를 만들어두면 인터페이스 구현 클래스와의 관계는 느슨해지면서 변화에 영향을 덜 받는 상태가 된다. 결합도가 낮다고 설명할 수 있다. 의존관계란 한쪽의 변화가 다른 쪽에 영향을 주는 것이라고 했으니, 인터페이스를 통해 의존관계를 제한해주면 그만큼 변경에서 자유로워지는 셈인 것이다.

* 의존관계 주입이란 다음과 같은 세 가지 조건을 충족하는 작업을 말한다.

  * 클래스 모델이나 코드에는 런타임 시점의 의존관계가 드러나지 않는다. 그러기 위해서는 인터페이스에만 의존하고 있어야 한다.
  * 런타임 시점의 의존관계는 컨테이너나 팩토리 같은 제 3의 존재가 결정한다.
  * 의존관계는 사용할 오브젝트에 대한 레퍼런스를 외부에서 주입해줌으로써 만들어진다.

  의존관계 주입의 핵심은 설계 시점에는 알지 못했던 두 오브젝트의 관계를 맺도록 도와주는 제 3의 존재가 있다는 것이다.

* DI는 자신이 사용할 오브젝트에 대한 선택과 생성 제어권을 외부로 넘기고 자신은 수동적으로 주입받은 오브젝트를 사용한다는 점에서 IoC의 개념에 잘 들어맞는다. 스프링 컨테이너의 IoC는 주로 의존관계 주입 또는 DI라는 데 초점이 맞춰져 있다. 그래서 스프링을 IoC 컨테이너 외에도 DI 컨테이너 또는 DI 프레임워크라고 부르는 것이다.

* DL은 미리 정해놓은 이름을 전달해서 그 이름에 해당하는 오브젝트를 찾는 의존관계 검색을 의미한다. 

* 의존관계는 인터페이스를 통해 결합도가 낮은 코드를 만드므로, 다른 책임을 가진 사용 의존관계에 있는 대상이 바뀌거나 변경되더라도 자신은 영향을 받지 않으며, 변경을 통한 다양한 확장 방법에는 자유롭다는 장점이 있다.

* 생성자가 아닌 수정자와 일반 메소드를 이용해서 주입을 해줄 수도 있다.

* 스프링은 자바 클래스를 이용하는 것 외에도, 다양한 방법을 통해 DI 의존관계 설정정보를 만들 수 있다. 가장 대표적인 것이 바로 XML이다. 

* ```java
  /*
  @Configuration => <beans>
  @Bean methodName() => <bean id="methodName">
  return new BeanClass(); => class="패키지..BeanClass">
  */
  @Bean
  public ConnectionMaker connectionMaker() {
    return new DConnectionMaker();
  }
  // <bean id="connectionMaker" class="패키지명...DConnectionMaker"/> 형식을 변환
  
  userDao.setConnectionMaker(connectionMaker());
  /*
  <bean id="userDao" class="패키지명...UserDao">
    <property name = "connectionMaker" ref = "connectionMaker"/>
  </bean>
  
  같은 인터페이스 타입의 빈을 여러 개 정의한 경우
  <beans>
    <bean id="localDBConnectionMaker" class="...LocalDBConnectionMaker"/>
    <bean id="testDBConnectionMaker" class="...TestDBConnectionMaker"/>
    <bean id="productionDBConnectionMaker" class="...ProductionDBConnectionMaker"/>
    <bean id="userDao" class="패키지명..UserDao">
      <property name="connectionMaker" ref="localDBConnectionMaker"/>
    </bean>
  </beans>
  ```

* ``ConnectionMaker``와 같이 DB커넥션을 생성해주는 기능은 이미 자바에서 ``DataSource``라는 인터페이스로 제공해주고 있다. 여러 개의 메소드를 가지고 있어 직접 구현하기에는 어려움이 있고 이미 다양한 방법으로 DB연결과 풀링 기능을 갖춘 많은 구현 클래스가 존재한다. 관심을 가질 메서드는 ``getConnection()``이다. 

* ```java
  @Bean
  public DataSource dataSource() {
    SimpleDriverDataSource dataSource = new SimpleDriverDataSource();
    dataSource.setDriverClass(com.mysql.cj.jdbc.Driver.class);
    dataSource.setUrl("jdbc:mysql://localhost:13306/db_name?serverTimezone=UTC&characterEncoding=UTF-8");
    dataSource.setUsername("root");
    dataSource.setPassword("root");
  
    return dataSource;
  }
  //다음과 같이 빈 등록을 해주고 UserDao 클래스 내부 코드를 ConnectionMaker가 아닌 DataSource의 getConnection()을 이용하도록 수정하였다.
  ```

* 위 코드의 ``setDriverClass``를 보면 다른 빈 오브젝트의 레퍼런스가 아닌 단순 정보도 오브젝트를  초기화하는 과정에서 수정자 메소드에 넣을 수 있다는 것을 알 수 있는데, 이때는 DI에서처럼 오브젝트의 구현 클래스를 다이내믹하게 바꿀 수 있게 해주는 목적이 아닌 클래스 외부에서 DB 연결정보와 같이 변경 가능한 정보를 설정해줄 수 있도록 만들기 위해서다. 예를 들어 DB 접속 아이디가 바뀌었더라도 클래스 코드는 수정해줄 필요가 없게 해주는 것이다. 텍스트나 단순 오브젝트 등을 수정자 메소드에 넣어주는 것을 스프링에서는 '값을 주입한다'고 말한다. 이것도 성격은 다르지만 일종의 DI라고 볼 수 있다. 사용할 오브젝트 자체를 바꾸지는 않지만 오브젝트의 특성은 외부에서 변경할 수 있기 때문이다. 

* XML에서는 ``<property name="driverClass" value="com.mysql.jdbc.Driver" />``의 형식을 사용하는데 어떻게 스트링 형식을 Class 타입의 파라미터를 갖는 수정자 메소드에 사용될 수 있을까? 이것이 가능한 이유는 스프링이 프로퍼티의 값을, 수정자 메소드의 파라미터 타입을 참고로 해서 적절한 형태로 변환해주기 때문이다. 파라미터 타입이 Class임을 확인하고 ``"com.mysql.jdbc.Driver"``라는 텍스트 값을 ``com.mysql.jdbc.Driver.class`` 오브젝트로 자동 변경해주는 것이다. 스프링은 기본 타입은 물론이고 Class, URL, File, Charset 같은 오브젝트로 변환할 수도 있다. 

***

