### PR TITLE
[파즈 조][케빈]1장 2주차 PR 제출합니다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,10 @@ repositories {
 }
 
 dependencies {
+    implementation group: 'org.springframework', name: 'spring-core', version: '5.2.9.RELEASE'
+    implementation group: 'org.springframework', name: 'spring-context', version: '5.2.9.RELEASE'
+    implementation group: 'org.springframework', name: 'spring-jdbc', version: '5.2.9.RELEASE'
+    implementation group: 'cglib', name: 'cglib', version: '3.3.0'
     implementation group: 'mysql', name: 'mysql-connector-java', version: '8.0.24'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,11 @@ dependencies {
     implementation group: 'org.springframework', name: 'spring-jdbc', version: '5.2.9.RELEASE'
     implementation group: 'cglib', name: 'cglib', version: '3.3.0'
     implementation group: 'mysql', name: 'mysql-connector-java', version: '8.0.24'
+
+    testImplementation 'junit:junit:4.12'
+    testImplementation group: 'org.springframework', name: 'spring-test', version: '5.3.7'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'
+    testCompile("org.assertj:assertj-core:3.11.1")
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
 }
 

--- a/src/main/java/springbook/dao/CountingDaoFactory.java
+++ b/src/main/java/springbook/dao/CountingDaoFactory.java
@@ -1,0 +1,24 @@
+package springbook.dao;
+
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class CountingDaoFactory {
+
+//    @Bean
+//    public UserDao userDao() {
+//        UserDao userDao = new UserDao();
+//        userDao.setDataSource(connectionMaker());
+//        return userDao;
+//    }
+//
+//    @Bean
+//    public ConnectionMaker connectionMaker() {
+//        return new CountingConnectionMaker(realConnectionMaker());
+//    }
+//
+//    @Bean
+//    public ConnectionMaker realConnectionMaker() {
+//        return new SimpleConnectionMaker();
+//    }
+}

--- a/src/main/java/springbook/dao/DaoFactory.java
+++ b/src/main/java/springbook/dao/DaoFactory.java
@@ -3,7 +3,6 @@ package springbook.dao;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.datasource.SimpleDriverDataSource;
-import springbook.dao.user.UserDao;
 
 import javax.sql.DataSource;
 

--- a/src/main/java/springbook/dao/DaoFactory.java
+++ b/src/main/java/springbook/dao/DaoFactory.java
@@ -1,24 +1,29 @@
 package springbook.dao;
 
-import springbook.dao.connection.ConnectionMaker;
-import springbook.dao.connection.SimpleConnectionMaker;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.datasource.SimpleDriverDataSource;
 import springbook.dao.user.UserDao;
 
+import javax.sql.DataSource;
+
+@Configuration
 public class DaoFactory {
 
+    @Bean
     public UserDao userDao() {
-        return new UserDao(connectionMaker());
+        UserDao userDao = new UserDao();
+        userDao.setDataSource(dataSource());
+        return userDao;
     }
 
-    public UserDao accountantDao() {
-        return new UserDao(connectionMaker());
-    }
-
-    public UserDao developerDao() {
-        return new UserDao(connectionMaker());
-    }
-
-    public ConnectionMaker connectionMaker() {
-        return new SimpleConnectionMaker();
+    @Bean
+    public DataSource dataSource() {
+        SimpleDriverDataSource simpleDriverDataSource = new SimpleDriverDataSource();
+        simpleDriverDataSource.setDriverClass(com.mysql.cj.jdbc.Driver.class);
+        simpleDriverDataSource.setUrl("jdbc:mysql://localhost:13306/tobi");
+        simpleDriverDataSource.setUsername("root");
+        simpleDriverDataSource.setPassword("root");
+        return simpleDriverDataSource;
     }
 }

--- a/src/main/java/springbook/dao/UserDao.java
+++ b/src/main/java/springbook/dao/UserDao.java
@@ -1,5 +1,6 @@
-package springbook.dao.user;
+package springbook.dao;
 
+import org.springframework.dao.EmptyResultDataAccessException;
 import springbook.domain.user.User;
 
 import javax.sql.DataSource;
@@ -28,15 +29,40 @@ public class UserDao {
         PreparedStatement preparedStatement = connection.prepareStatement("SELECT * FROM USERS WHERE ID = ?");
         preparedStatement.setString(1, id);
         ResultSet resultSet = preparedStatement.executeQuery();
-        resultSet.next();
-        User user = new User();
-        user.setId(resultSet.getString("id"));
-        user.setName(resultSet.getString("name"));
-        user.setPassword(resultSet.getString("password"));
+        User user = null;
+        if (resultSet.next()) {
+            user = new User();
+            user.setId(resultSet.getString("id"));
+            user.setName(resultSet.getString("name"));
+            user.setPassword(resultSet.getString("password"));
+        }
+        if (user == null) {
+            throw new EmptyResultDataAccessException(1);
+        }
         resultSet.close();
         preparedStatement.close();
         connection.close();
         return user;
+    }
+
+    public void deleteAll() throws SQLException {
+        Connection connection = dataSource.getConnection();
+        PreparedStatement preparedStatement = connection.prepareStatement("delete from users");
+        preparedStatement.executeUpdate();
+        preparedStatement.close();
+        connection.close();
+    }
+
+    public int getCount() throws SQLException {
+        Connection connection = dataSource.getConnection();
+        PreparedStatement preparedStatement = connection.prepareStatement("select count(*) from users");
+        ResultSet resultSet = preparedStatement.executeQuery();
+        resultSet.next();
+        int count = resultSet.getInt(1);
+        resultSet.close();
+        preparedStatement.close();
+        connection.close();
+        return count;
     }
 
     public void setDataSource(DataSource dataSource) {

--- a/src/main/java/springbook/dao/connection/CountingConnectionMaker.java
+++ b/src/main/java/springbook/dao/connection/CountingConnectionMaker.java
@@ -1,0 +1,24 @@
+package springbook.dao.connection;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+public class CountingConnectionMaker implements ConnectionMaker {
+
+    private final ConnectionMaker realConnectionMaker;
+    private int counter = 0;
+
+    public CountingConnectionMaker(ConnectionMaker realConnectionMaker) {
+        this.realConnectionMaker = realConnectionMaker;
+    }
+
+    @Override
+    public Connection makeConnection() throws ClassNotFoundException, SQLException {
+        counter++;
+        return realConnectionMaker.makeConnection();
+    }
+
+    public int getCounter() {
+        return counter;
+    }
+}

--- a/src/main/java/springbook/dao/user/UserDao.java
+++ b/src/main/java/springbook/dao/user/UserDao.java
@@ -1,8 +1,8 @@
 package springbook.dao.user;
 
-import springbook.dao.connection.ConnectionMaker;
 import springbook.domain.user.User;
 
+import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -10,14 +10,10 @@ import java.sql.SQLException;
 
 public class UserDao {
 
-    private ConnectionMaker connectionMaker;
+    private DataSource dataSource;
 
-    public UserDao(ConnectionMaker connectionMaker) {
-        this.connectionMaker = connectionMaker;
-    }
-
-    public void addUser(User user) throws ClassNotFoundException, SQLException {
-        Connection connection = connectionMaker.makeConnection();
+    public void addUser(User user) throws SQLException {
+        Connection connection = dataSource.getConnection();
         PreparedStatement preparedStatement = connection.prepareStatement("INSERT INTO USERS (ID, NAME, PASSWORD) VALUES (?, ?, ?)");
         preparedStatement.setString(1, user.getId());
         preparedStatement.setString(2, user.getName());
@@ -27,8 +23,8 @@ public class UserDao {
         connection.close();
     }
 
-    public User getUser(String id) throws SQLException, ClassNotFoundException {
-        Connection connection = connectionMaker.makeConnection();
+    public User getUser(String id) throws SQLException {
+        Connection connection = dataSource.getConnection();
         PreparedStatement preparedStatement = connection.prepareStatement("SELECT * FROM USERS WHERE ID = ?");
         preparedStatement.setString(1, id);
         ResultSet resultSet = preparedStatement.executeQuery();
@@ -41,5 +37,9 @@ public class UserDao {
         preparedStatement.close();
         connection.close();
         return user;
+    }
+
+    public void setDataSource(DataSource dataSource) {
+        this.dataSource = dataSource;
     }
 }

--- a/src/main/java/springbook/domain/user/User.java
+++ b/src/main/java/springbook/domain/user/User.java
@@ -6,6 +6,15 @@ public class User {
     private String name;
     private String password;
 
+    public User() {
+    }
+
+    public User(String id, String name, String password) {
+        this.id = id;
+        this.name = name;
+        this.password = password;
+    }
+
     public String getId() {
         return id;
     }

--- a/src/main/java/springbook/test/UserDaoAnnotationTest.java
+++ b/src/main/java/springbook/test/UserDaoAnnotationTest.java
@@ -2,9 +2,8 @@ package springbook.test;
 
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
-import springbook.dao.CountingDaoFactory;
-import springbook.dao.connection.CountingConnectionMaker;
-import springbook.dao.user.UserDao;
+import springbook.dao.DaoFactory;
+import springbook.dao.UserDao;
 import springbook.domain.user.User;
 
 import java.sql.SQLException;
@@ -12,7 +11,7 @@ import java.sql.SQLException;
 public class UserDaoAnnotationTest {
 
     public static void main(String[] args) throws SQLException {
-        ApplicationContext applicationContext = new AnnotationConfigApplicationContext(CountingDaoFactory.class);
+        ApplicationContext applicationContext = new AnnotationConfigApplicationContext(DaoFactory.class);
         UserDao userDao = applicationContext.getBean("userDao", UserDao.class);
         User user = new User();
 
@@ -23,11 +22,12 @@ public class UserDaoAnnotationTest {
         System.out.println(user.getId() + "등록 성공");
 
         User user2 = userDao.getUser(user.getId());
-        System.out.println(user2.getName());
-        System.out.println(user2.getPassword());
-        System.out.println(user2.getId() + "조회 성공");
-
-        CountingConnectionMaker countingConnectionMaker = applicationContext.getBean("connectionMaker", CountingConnectionMaker.class);
-        System.out.println(countingConnectionMaker.getCounter());
+        if (!user.getName().equals(user2.getName())) {
+            System.out.println("테스트 실패 (name)");
+        } else if (!user.getPassword().equals(user2.getPassword())) {
+            System.out.println("테스트 실패 (password)");
+        } else {
+            System.out.println("조회 테스트 성공");
+        }
     }
 }

--- a/src/main/java/springbook/test/UserDaoAnnotationTest.java
+++ b/src/main/java/springbook/test/UserDaoAnnotationTest.java
@@ -1,0 +1,33 @@
+package springbook.test;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import springbook.dao.CountingDaoFactory;
+import springbook.dao.connection.CountingConnectionMaker;
+import springbook.dao.user.UserDao;
+import springbook.domain.user.User;
+
+import java.sql.SQLException;
+
+public class UserDaoAnnotationTest {
+
+    public static void main(String[] args) throws SQLException {
+        ApplicationContext applicationContext = new AnnotationConfigApplicationContext(CountingDaoFactory.class);
+        UserDao userDao = applicationContext.getBean("userDao", UserDao.class);
+        User user = new User();
+
+        user.setId("whiteship");
+        user.setName("백기선");
+        user.setPassword("married");
+        userDao.addUser(user);
+        System.out.println(user.getId() + "등록 성공");
+
+        User user2 = userDao.getUser(user.getId());
+        System.out.println(user2.getName());
+        System.out.println(user2.getPassword());
+        System.out.println(user2.getId() + "조회 성공");
+
+        CountingConnectionMaker countingConnectionMaker = applicationContext.getBean("connectionMaker", CountingConnectionMaker.class);
+        System.out.println(countingConnectionMaker.getCounter());
+    }
+}

--- a/src/main/java/springbook/test/UserDaoXmlTest.java
+++ b/src/main/java/springbook/test/UserDaoXmlTest.java
@@ -1,15 +1,17 @@
 package springbook.test;
 
-import springbook.dao.DaoFactory;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
 import springbook.dao.user.UserDao;
 import springbook.domain.user.User;
 
 import java.sql.SQLException;
 
-public class UserDaoTest {
+public class UserDaoXmlTest {
 
-    public static void main(String[] args) throws SQLException, ClassNotFoundException {
-        UserDao userDao = new DaoFactory().userDao();
+    public static void main(String[] args) throws SQLException {
+        ApplicationContext applicationContext = new ClassPathXmlApplicationContext("applicationContext.xml");
+        UserDao userDao = applicationContext.getBean("userDao", UserDao.class);
         User user = new User();
 
         user.setId("whiteship");

--- a/src/main/java/springbook/test/UserDaoXmlTest.java
+++ b/src/main/java/springbook/test/UserDaoXmlTest.java
@@ -2,7 +2,7 @@ package springbook.test;
 
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
-import springbook.dao.user.UserDao;
+import springbook.dao.UserDao;
 import springbook.domain.user.User;
 
 import java.sql.SQLException;

--- a/src/main/resources/applicationContext.xml
+++ b/src/main/resources/applicationContext.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://www.springframework.org/schema/beans"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+       http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+    <bean id="userDao" class="springbook.dao.user.UserDao">
+        <property name="dataSource" ref="dataSource"/>
+    </bean>
+    <bean id="dataSource" class="org.springframework.jdbc.datasource.SimpleDriverDataSource">
+        <property name="driverClass" value="com.mysql.cj.jdbc.Driver"/>
+        <property name="url" value="jdbc:mysql://localhost:13306/tobi"/>
+        <property name="username" value="root"/>
+        <property name="password" value="root"/>
+    </bean>
+</beans>

--- a/src/main/resources/test-applicationContext.xml
+++ b/src/main/resources/test-applicationContext.xml
@@ -8,7 +8,7 @@
     </bean>
     <bean id="dataSource" class="org.springframework.jdbc.datasource.SimpleDriverDataSource">
         <property name="driverClass" value="com.mysql.cj.jdbc.Driver"/>
-        <property name="url" value="jdbc:mysql://localhost:13306/tobi"/>
+        <property name="url" value="jdbc:mysql://localhost:13306/testdb"/>
         <property name="username" value="root"/>
         <property name="password" value="root"/>
     </bean>

--- a/src/test/java/springbook/dao/LearningTest.java
+++ b/src/test/java/springbook/dao/LearningTest.java
@@ -1,0 +1,43 @@
+package springbook.dao;
+
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(locations = "/test-applicationContext.xml")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class LearningTest {
+
+    private static Set<LearningTest> testObjects = new HashSet<>();
+    private static ApplicationContext contextObject = null;
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Test
+    @Order(1)
+    void test1() {
+        testObjects.add(this);
+        assertThat(contextObject).isNull();
+        contextObject = this.applicationContext;
+    }
+
+    @Test
+    @Order(2)
+    void test2() {
+        testObjects.add(this);
+        assertThat(contextObject).isSameAs(applicationContext);
+        contextObject = this.applicationContext;
+    }
+}

--- a/src/test/java/springbook/dao/UserDaoTest.java
+++ b/src/test/java/springbook/dao/UserDaoTest.java
@@ -1,0 +1,84 @@
+package springbook.dao;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import springbook.domain.user.User;
+
+import java.sql.SQLException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(locations = "/test-applicationContext.xml")
+class UserDaoTest {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+    @Autowired(required = true)
+    private UserDao userDao;
+    private User user1;
+    private User user2;
+    private User user3;
+
+    public static void main(String[] args) {
+        //JUnitCore.main("springbook.dao.UserDaoTest"); IDE 지원을 안 받고 실행한다면
+    }
+
+    @BeforeEach
+    void setUp() {
+        System.out.println(this);
+        System.out.println(this.applicationContext);
+        user1 = new User("gyumee", "park", "springno1");
+        user2 = new User("leegw700", "lee", "springno2");
+        user3 = new User("bumjin", "박범진", "springno3");
+    }
+
+    @Test
+    void addAndGet() throws SQLException {
+        userDao.deleteAll();
+        assertThat(userDao.getCount()).isZero();
+
+        userDao.addUser(user1);
+        userDao.addUser(user2);
+        assertThat(userDao.getCount()).isEqualTo(2);
+
+        User user1get = userDao.getUser(user1.getId());
+        assertThat(user1get.getName()).isEqualTo(user1.getName());
+        assertThat(user1get.getPassword()).isEqualTo(user1.getPassword());
+
+        User user2get = userDao.getUser(user2.getId());
+        assertThat(user2get.getName()).isEqualTo(user2.getName());
+        assertThat(user2get.getPassword()).isEqualTo(user2.getPassword());
+    }
+
+    @Test
+    void getUserFailure() throws SQLException {
+        userDao.deleteAll();
+        assertThat(userDao.getCount()).isZero();
+
+        assertThatCode(() -> userDao.getUser("unknown"))
+                .isInstanceOf(EmptyResultDataAccessException.class);
+    }
+
+    @Test
+    void count() throws SQLException {
+        userDao.deleteAll();
+        assertThat(userDao.getCount()).isZero();
+
+        userDao.addUser(user1);
+        assertThat(userDao.getCount()).isEqualTo(1);
+
+        userDao.addUser(user2);
+        assertThat(userDao.getCount()).isEqualTo(2);
+
+        userDao.addUser(user3);
+        assertThat(userDao.getCount()).isEqualTo(3);
+    }
+}


### PR DESCRIPTION
* 학습 내용 정리
   * https://xlffm3.github.io/spring%20&%20spring%20boot/toby-spring-chapter1/#2-spring%EC%9D%98-ioc
 
---

## 프레임워크의 비침투성

우리가 이번 주차에 학습한 내용 중에는 **의존관계 검색**이라는 방식이 있었는데요.

> UserDao.java

```java
public UserDao() {
    AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(DaoFactory.class);
    this.connectionMaker = context.getBean("connectionMaker", ConnectionMaker.class);
} 
```

* 주입을 받는 방식이 아니라, 자신이 사용할 의존 객체를 컨테이너에게 직접 요청하여 가져오는 방식.
  * 의존 객체의 내부 정보(의존성, 구현 클래스) 등은 알지 못한다. 즉, 자신이 필요로 하는 객체를 능동적으로 찾으나, 해당 Bean의 의존 관계 설정과 생성 및 구현체 등의 로직은 여전히 외부 컨테이너에게 위임한 상태이다.
* UserDao 클래스 코드에 관심사가 분리되지 않아 **대부분의 경우** DI가 더 낫다.
  * DI를 받을 수 없는 엔트리 포인트 등에서나 사용. 

Spring Core Technologies docs에는 다음과 같이 명시되어 있습니다.

> You can then use getBean to retrieve instances of your beans. The ApplicationContext interface has a few other methods for retrieving beans, but, ideally, your application code should never use them. Indeed, your application code should have no calls to the getBean() method at all and thus have no dependency on Spring APIs at all.

* 이상적으로는 ``getBean()``을 사용하지 말자. 어플리케이션 코드가 Spring API와의 의존성이 생긴다.
   * 현재 우리는 실습 때문에 어플리케이션의 엔트리 포인트에서는 어쩔 수 없이 ``getBean()``을 호출하지만, 이 마저도 SpringBoot에서는 쓸 일이 거의 없음.
   * Spring 관련 Configuration에서는 사용할수 있을지 몰라도, 어플리케이션의 핵심적인 부분(도메인 모델 등)에서 사용하게 된다면?
   * 프레임워크의 코드가 침투하게 되어 추후 다른 프레임워크로의 마이그레이션 등 유지보수나 테스트가 어려워진다.
 