### PR TITLE
[검프 조][피카]1장 2주차 PR 제출합니다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,10 @@ dependencies {
 
     testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.19.0'
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+    implementation group: 'org.springframework', name: 'spring-core', version: '5.2.8.RELEASE'
+    implementation group: 'org.springframework', name: 'spring-context', version: '5.2.8.RELEASE'
+    implementation group: 'org.springframework', name: 'spring-jdbc', version: '5.2.8.RELEASE'
+    implementation group: 'com.h2database', name: 'h2', version: '1.4.200'
 }
 
 test {

--- a/src/main/java/dao/counting/ConnectionMaker.java
+++ b/src/main/java/dao/counting/ConnectionMaker.java
@@ -1,0 +1,8 @@
+package dao.counting;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+public interface ConnectionMaker {
+    public Connection makeNewConnection() throws SQLException, ClassNotFoundException;
+}

--- a/src/main/java/dao/counting/CountingConnectionMaker.java
+++ b/src/main/java/dao/counting/CountingConnectionMaker.java
@@ -1,0 +1,23 @@
+package dao.counting;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+public class CountingConnectionMaker implements ConnectionMaker {
+    int counter = 0;
+    private ConnectionMaker realConnectionMaker;
+
+    public CountingConnectionMaker(ConnectionMaker realConnectionMaker) {
+        this.realConnectionMaker = realConnectionMaker;
+    }
+
+    @Override
+    public Connection makeNewConnection() throws SQLException, ClassNotFoundException {
+        this.counter++;
+        return realConnectionMaker.makeNewConnection();
+    }
+
+    public int getCounter() {
+        return this.counter;
+    }
+}

--- a/src/main/java/dao/counting/CountingDaoFactory.java
+++ b/src/main/java/dao/counting/CountingDaoFactory.java
@@ -1,0 +1,21 @@
+package dao.counting;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class CountingDaoFactory {
+    @Bean
+    public UserDao userDao() {
+        return new UserDao(connectionMaker());
+    }
+
+    @Bean
+    public ConnectionMaker connectionMaker() {
+        return new CountingConnectionMaker(realConnectionMaker());
+    }
+    @Bean
+    public ConnectionMaker realConnectionMaker() {
+        return new DConnectionMaker();
+    }
+}

--- a/src/main/java/dao/counting/DConnectionMaker.java
+++ b/src/main/java/dao/counting/DConnectionMaker.java
@@ -1,0 +1,15 @@
+package dao.counting;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+public class DConnectionMaker implements ConnectionMaker {
+    @Override
+    public Connection makeNewConnection() throws SQLException, ClassNotFoundException  {
+        Class.forName("org.h2.Driver");
+        Connection c = DriverManager.getConnection(
+                "jdbc:h2:tcp://localhost/~/test", "sa", "");
+        return c;
+    }
+}

--- a/src/main/java/dao/counting/UserDao.java
+++ b/src/main/java/dao/counting/UserDao.java
@@ -1,0 +1,80 @@
+package dao.counting;
+
+import domain.User;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class UserDao {
+
+    ConnectionMaker connectionMaker;
+
+    public UserDao(ConnectionMaker connectionMaker) {
+        this.connectionMaker = connectionMaker;
+    }
+    /*
+     * User 추가
+     */
+    public void add(User user) throws ClassNotFoundException, SQLException {
+
+        Connection c = connectionMaker.makeNewConnection();
+        PreparedStatement ps = c.prepareStatement(
+                "insert into users(id, name, password) values(?,?,?)");
+        ps.setString(1, user.getId());
+        ps.setString(2, user.getName());
+        ps.setString(3, user.getPassword());
+        ps.executeUpdate();
+        ps.close();
+        c.close();
+    }
+
+    /*
+    * User 정보 가져오기
+    */
+    public User get(String id) throws ClassNotFoundException, SQLException {
+
+        Connection c = connectionMaker.makeNewConnection();
+        PreparedStatement ps = c.prepareStatement(
+                "select * from users where id = ?");
+        ps.setString(1, id);
+        ResultSet rs = ps.executeQuery();
+        rs.next();
+        User user = new User();
+        user.setId(rs.getString("id"));
+        user.setName(rs.getString("name"));
+        user.setPassword(rs.getString("password"));
+        rs.close();
+        ps.close();
+        c.close();
+        return user;
+    }
+
+    /*
+     * User 삭제
+     */
+    public void delete(String id) throws ClassNotFoundException, SQLException {
+
+        Connection c = connectionMaker.makeNewConnection();
+        PreparedStatement ps = c.prepareStatement(
+                "delete from users where id = ?");
+        ps.setString(1, id);
+        ps.executeUpdate();
+        ps.close();
+        c.close();
+    }
+
+    /*
+     * User 정보 초기화
+     */
+    public void init() throws ClassNotFoundException, SQLException {
+
+        Connection c = connectionMaker.makeNewConnection();
+        PreparedStatement ps = c.prepareStatement(
+                "TRUNCATE TABLE users");
+        ps.executeUpdate();
+        ps.close();
+        c.close();
+    }
+}

--- a/src/test/java/dao/abstract_class/UserDaoTest.java
+++ b/src/test/java/dao/abstract_class/UserDaoTest.java
@@ -1,7 +1,5 @@
-package abstract_class;
+package dao.abstract_class;
 
-import dao.abstract_class.NUserDao;
-import dao.abstract_class.UserDao;
 import domain.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/dao/class_separate/UserDaoTest.java
+++ b/src/test/java/dao/class_separate/UserDaoTest.java
@@ -1,8 +1,5 @@
-package class_separate;
+package dao.class_separate;
 
-import dao.class_separate.ConnectionMaker;
-import dao.class_separate.DConnectionMaker;
-import dao.class_separate.UserDao;
 import domain.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/dao/counting/UserDaoConnectionCountingTest.java
+++ b/src/test/java/dao/counting/UserDaoConnectionCountingTest.java
@@ -1,0 +1,14 @@
+package dao.counting;
+
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+public class UserDaoConnectionCountingTest {
+    public static void main(String[] args) {
+        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(CountingDaoFactory.class);
+        UserDao dao = context.getBean("userDao", UserDao.class);
+
+        CountingConnectionMaker ccm = context.getBean("connectionMaker", CountingConnectionMaker.class);
+
+        System.out.println("Connection counter : " + ccm.getCounter());
+    }
+}

--- a/src/test/java/dao/ioc/UserDaoTest.java
+++ b/src/test/java/dao/ioc/UserDaoTest.java
@@ -1,7 +1,5 @@
-package ioc;
+package dao.ioc;
 
-import dao.ioc.DaoFactory;
-import dao.ioc.UserDao;
 import domain.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
너무 늦었네요.. ㅠㅠ
전체적으로 이해는 되지만
머리속으로는 예시가 그려지지 않네요..! 조금 더 공부하겠습니다!

<br>

## 스프링의 IoC

### 빈 팩토리 vs 애플리케이션 컨텍스트

__빈 팩토리__
스프링에서 빈의 생성과 관계설정 같은 제어를 담당하는 IoC 오브젝트
애플리케이션 컨텍스트보다는 IoC 기본 기능에 초점을 맞춤

__애플리케이션 컨텍스트__
IoC 방식을 따라 만들어진 일종의 빈 팩토리
빈 팩토리 기능 이외에 추가적인 기능이 포함되어 있음
빈 팩토리를 상속받고 있음

### 애플리케이션 컨텍스트의 동작 방식

`@Configuration`이 붙은 DaoFactory를 찾아가 `@Bean`으로 등록되어 있는 userDao()를 가져다 사용한다.

만약 같은 종류의 Bean(?)이라면 어떤 것을 찾아 사용할까??

### 스프링 IoC의 용어 정리
__빈__
- 스프링이 IoC 방식으로 관리하는 오브젝트
- 스프링이 직접 생성과 제어를 담당하는 오브젝트만을 빈이라고 부름

__빈 팩토리__
- 스프링의 IoC를 담당하는 핵심 컨테이너
- 빈을 등록, 생성, 조회 등 부가적으로 빈을 관리하는 기능을 담당
- 일반적으로 빈 팩토리를 바로 사용하지 않고 애플리케이션 컨텍스트를 이용

__애플리케이션 컨텍스트__
- 빈 팩토리를 확장한 IoC 컨테이너
- 빈을 관리하는 빈 팩토리 이외에, 스프링에서 제공하는 애플리케이션 지원 기능을 모두 포함한다

__설정 정보/ 메타정보__
- 스프링의 설정 정보란 애플리케이션 컨텍스트 또는 빈 팩토리가 IoC를 적용하기 위해 사용하는 메타정보를 말한다.

__컨테이너 또는 IoC 컨테이너__
- IoC 방식으로 빈을 관리한다는 의미에서 애플리케이션 컨텍스트나 빈 팩토리를 컨테이너 또는 IoC 컨테이너라고함

<br>


## 싱글톤 레지스트리와 오브젝트 스코프

애플리케이션 컨텍스트는 싱글톤을 저장하고 관리하는 __싱글톤 레지스트리__ 이다.
스프링은 기본적으로 별다른 설정을 하지 않으면 내부에서 생성하는 빈 오브젝트를 모두 싱글톤으로 만든다.

### 왜 싱글톤으로 만들까?
- 스프링의 적용 대상은 주로 자바 엔터프라이즈 기술을 사용하는 서버 환경이기 때문
- 대규모의 서버 환경에서 서버 하나당 초당 수십에서 수백 번의 요청이 들어옴
- 그때마다 로직을 담당하는 오브젝트를 새로 만들어서 사용하게 되면 너무 많은 오브젝트가 만들어져 과부하가 옴
- 따라서 오브젝트를 하나로 만드는 싱글톤 방식을 사용

### 싱글톤의 한계
- private 생성자를 갖고 있기 때문에 상속할 수 없다
- 싱글톤은 테스트하기가 힘들다
- 서버환경에서는 싱글톤이 하나만 만들어지는 것을 보장하지 못한다
- 싱글톤의 사용은 전역 상태를 만들 수 있기 때문에 바람직하지 못하다

### 싱글톤 레지스트리

스프링이 주로 사용되는 서버 환경상 싱글톤이 필요하지만, 앞서 말한 단점들 때문에 꺼려진다. 스프링은 이러한 단점을 개선하기위해 직접 싱글톤 형태의 오브젝트를 만들고 관리하는 기능을 제공한다. 그것이 바로 __싱글톤 레지스트리__ 다.

~~스프링 만세...~~

#### 싱글톤 레지스트리 장점
- static 메소드와 private 생성자를 사용해야 하는 비정상적인 클래스가 아닌, 평범한 자바 클래스를 싱글톤으로 활용하게 해준다.
- 평범한 자바 클래스라도 IoC 방식의 컨테이너를 사용해서 생성과 관계설정, 사용 등에 대한 제어권을 컨테이너에게 넘기면 손쉽게 싱글톤 방식으로 만들어져 관리할 수 있다.
- 싱글톤 방식으로 사용될 애플리케이션 클래스라도 public 생성자를 가질 수 있다.
- 이에 따라 테스트도 자유롭게 할 수 있다.

#### 싱글톤과 오브젝트의 상태

멀티 스레트 환경에서 싱글톤 사용은 위험하다.
- 상태 정보를 내부에 갖고 있지 않은 무상태 방식으로 만들어져야한다
- 여러 인스턴스 변수를 수정하는 것은 위험(당연!!)
- 읽기 전용이면 문제가 없다

### 의존관계 주입(DI)

__의존관계__

>A가 B에게 의존하고 있다
![](images/두%20개의%20클래스%20또는%20모듈이%20.png)
B가 변경되면 A에 영향을 미친다. 하지만 반대로 A가 변경되도 B에 영향을 미치지 않는다.

- 설계 시점과 코드에는 클래스와 인터페이스 사이의 느슨한 의존관계만 만든다.
- 런타임 시에 구체적인 오브젝트를 제3자(DI 컨테이너)의 도움으로 주입받는다.