### PR TITLE
[고양이조] 케빈 4장 PR 제출합니다.

### DIFF
--- a/src/main/java/springbook/dao/DaoFactory.java
+++ b/src/main/java/springbook/dao/DaoFactory.java
@@ -10,10 +10,10 @@ import javax.sql.DataSource;
 public class DaoFactory {
 
     @Bean
-    public UserDao userDao() {
-        UserDao userDao = new UserDao();
-        userDao.setDataSource(dataSource());
-        return userDao;
+    public UserDaoJdbc userDao() {
+        UserDaoJdbc userDaoJdbc = new UserDaoJdbc();
+        userDaoJdbc.setDataSource(dataSource());
+        return userDaoJdbc;
     }
 
     @Bean

--- a/src/main/java/springbook/dao/UserDao.java
+++ b/src/main/java/springbook/dao/UserDao.java
@@ -1,49 +1,18 @@
 package springbook.dao;
 
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.core.RowMapper;
 import springbook.domain.user.User;
 
-import javax.sql.DataSource;
-import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.util.List;
 
-public class UserDao {
+public interface UserDao {
 
-    private JdbcTemplate jdbcTemplate;
-    private RowMapper<User> rowMapper = new RowMapper() {
-        @Override
-        public User mapRow(ResultSet rs, int rowNum) throws SQLException {
-            User user = new User();
-            user.setId(rs.getString("id"));
-            user.setName(rs.getString("name"));
-            user.setPassword(rs.getString("password"));
-            return user;
-        }
-    };
+    public void addUser(User user);
 
-    public void addUser(User user) {
-        this.jdbcTemplate.update("insert into users(id, name, password) values(?,?,?)", user.getId(), user.getName(), user.getPassword());
-    }
+    public User getUser(String id);
 
-    public User getUser(String id) throws SQLException {
-        return this.jdbcTemplate.queryForObject("select * from users where id = ?", new Object[]{id}, rowMapper);
-    }
+    public void deleteAll();
 
-    public void deleteAll() {
-        jdbcTemplate.update("delete from users");
-    }
+    public int getCount();
 
-    public int getCount() throws SQLException {
-        return jdbcTemplate.queryForObject("select count(*) from users", Integer.class);
-    }
-
-    public void setDataSource(DataSource dataSource) {
-        this.jdbcTemplate = new JdbcTemplate(dataSource);
-    }
-
-    public List<User> getAll() {
-        return jdbcTemplate.query("select * from users order by id", rowMapper);
-    }
+    public List<User> getAll();
 }

--- a/src/main/java/springbook/dao/UserDaoJdbc.java
+++ b/src/main/java/springbook/dao/UserDaoJdbc.java
@@ -1,0 +1,49 @@
+package springbook.dao;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import springbook.domain.user.User;
+
+import javax.sql.DataSource;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+public class UserDaoJdbc implements UserDao {
+
+    private JdbcTemplate jdbcTemplate;
+    private RowMapper<User> rowMapper = new RowMapper() {
+        @Override
+        public User mapRow(ResultSet rs, int rowNum) throws SQLException {
+            User user = new User();
+            user.setId(rs.getString("id"));
+            user.setName(rs.getString("name"));
+            user.setPassword(rs.getString("password"));
+            return user;
+        }
+    };
+
+    public void addUser(User user) {
+        this.jdbcTemplate.update("insert into users(id, name, password) values(?,?,?)", user.getId(), user.getName(), user.getPassword());
+    }
+
+    public User getUser(String id) {
+        return this.jdbcTemplate.queryForObject("select * from users where id = ?", new Object[]{id}, rowMapper);
+    }
+
+    public void deleteAll() {
+        jdbcTemplate.update("delete from users");
+    }
+
+    public int getCount() {
+        return jdbcTemplate.queryForObject("select count(*) from users", Integer.class);
+    }
+
+    public void setDataSource(DataSource dataSource) {
+        this.jdbcTemplate = new JdbcTemplate(dataSource);
+    }
+
+    public List<User> getAll() {
+        return jdbcTemplate.query("select * from users order by id", rowMapper);
+    }
+}

--- a/src/main/java/springbook/test/UserDaoAnnotationTest.java
+++ b/src/main/java/springbook/test/UserDaoAnnotationTest.java
@@ -3,7 +3,7 @@ package springbook.test;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import springbook.dao.DaoFactory;
-import springbook.dao.UserDao;
+import springbook.dao.UserDaoJdbc;
 import springbook.domain.user.User;
 
 import java.sql.SQLException;
@@ -12,16 +12,16 @@ public class UserDaoAnnotationTest {
 
     public static void main(String[] args) throws SQLException {
         ApplicationContext applicationContext = new AnnotationConfigApplicationContext(DaoFactory.class);
-        UserDao userDao = applicationContext.getBean("userDao", UserDao.class);
+        UserDaoJdbc userDaoJdbc = applicationContext.getBean("userDao", UserDaoJdbc.class);
         User user = new User();
 
         user.setId("whiteship");
         user.setName("백기선");
         user.setPassword("married");
-        userDao.addUser(user);
+        userDaoJdbc.addUser(user);
         System.out.println(user.getId() + "등록 성공");
 
-        User user2 = userDao.getUser(user.getId());
+        User user2 = userDaoJdbc.getUser(user.getId());
         if (!user.getName().equals(user2.getName())) {
             System.out.println("테스트 실패 (name)");
         } else if (!user.getPassword().equals(user2.getPassword())) {

--- a/src/main/java/springbook/test/UserDaoXmlTest.java
+++ b/src/main/java/springbook/test/UserDaoXmlTest.java
@@ -2,7 +2,7 @@ package springbook.test;
 
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
-import springbook.dao.UserDao;
+import springbook.dao.UserDaoJdbc;
 import springbook.domain.user.User;
 
 import java.sql.SQLException;
@@ -11,16 +11,16 @@ public class UserDaoXmlTest {
 
     public static void main(String[] args) throws SQLException {
         ApplicationContext applicationContext = new ClassPathXmlApplicationContext("applicationContext.xml");
-        UserDao userDao = applicationContext.getBean("userDao", UserDao.class);
+        UserDaoJdbc userDaoJdbc = applicationContext.getBean("userDao", UserDaoJdbc.class);
         User user = new User();
 
         user.setId("whiteship");
         user.setName("백기선");
         user.setPassword("married");
-        userDao.addUser(user);
+        userDaoJdbc.addUser(user);
         System.out.println(user.getId() + "등록 성공");
 
-        User user2 = userDao.getUser(user.getId());
+        User user2 = userDaoJdbc.getUser(user.getId());
         System.out.println(user2.getName());
         System.out.println(user2.getPassword());
         System.out.println(user2.getId() + "조회 성공");

--- a/src/main/resources/applicationContext.xml
+++ b/src/main/resources/applicationContext.xml
@@ -3,7 +3,7 @@
        xmlns="http://www.springframework.org/schema/beans"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
        http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
-    <bean id="userDao" class="springbook.dao.UserDao">
+    <bean id="userDaoJdbc" class="springbook.dao.UserDaoJdbc">
         <property name="dataSource" ref="dataSource"/>
     </bean>
     <bean id="dataSource" class="org.springframework.jdbc.datasource.SimpleDriverDataSource">

--- a/src/main/resources/test-applicationContext.xml
+++ b/src/main/resources/test-applicationContext.xml
@@ -3,7 +3,7 @@
        xmlns="http://www.springframework.org/schema/beans"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
        http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
-    <bean id="userDao" class="springbook.dao.UserDao">
+    <bean id="userDaoJdbc" class="springbook.dao.UserDaoJdbc">
         <property name="dataSource" ref="dataSource"/>
     </bean>
     <bean id="dataSource" class="org.springframework.jdbc.datasource.SimpleDriverDataSource">


### PR DESCRIPTION
학습 내용
* https://xlffm3.github.io/spring%20&%20spring%20boot/toby-spring-chapter4/

과거에는 **일말의 복구 가능성이 있으면 checked exception을 던진다**는 것이,
현재에 들어서는 **복구 가능성이 낮다면 unchecked exception을 던진다**로 변한게 신기했어요. 이러한 uncheckedException이 예외 전파, 사실상 복구 불능으로 인한 불필요함 등 말고도 다른 이상적인 dao 인터페이스 분리에 악영향을 끼치다니!

그런데 똑똑하신 api 개발자 분들은 이런 점들을 생각하지 못하고 checked exception을 사용한 것일까요? 아니면 그 당시 하드웨어 스펙 && 표준 기술이 변하지 않을 것임이라는 생각 등 때문에 사용한 것일까요? ㅎㅎ "그당시에는 이게 최선이었다" 라고 고려했을 이유가 궁금하네요