### PR TITLE
[고양이조] 마크 4장 PR 제출합니다.

### DIFF
--- a/src/main/java/com/binghe/ch04/DaoFactory.java
+++ b/src/main/java/com/binghe/ch04/DaoFactory.java
@@ -1,0 +1,27 @@
+package com.binghe.ch04;
+
+import com.binghe.ch04.dao.UserDao;
+import com.binghe.ch04.dao.UserDaoJdbc;
+import javax.sql.DataSource;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+@Configuration
+public class DaoFactory {
+
+    @Bean
+    public UserDao userDao(){
+        return new UserDaoJdbc(dataSource());
+    }
+
+    @Bean
+    public DataSource dataSource() {
+        DriverManagerDataSource dataSource = new DriverManagerDataSource();
+        dataSource.setDriverClassName("org.h2.Driver");
+        dataSource.setUrl("jdbc:h2:tcp://localhost/~/toby");
+        dataSource.setUsername("sa");
+        dataSource.setPassword("");
+        return dataSource;
+    }
+}

--- a/src/main/java/com/binghe/ch04/dao/UserDao.java
+++ b/src/main/java/com/binghe/ch04/dao/UserDao.java
@@ -1,0 +1,12 @@
+package com.binghe.ch04.dao;
+
+import com.binghe.ch04.domain.User;
+import java.util.List;
+
+public interface UserDao {
+    void add(User user);
+    User get(String id);
+    List<User> getAll();
+    void deleteAll();
+    int getCount();
+}

--- a/src/main/java/com/binghe/ch04/dao/UserDaoJdbc.java
+++ b/src/main/java/com/binghe/ch04/dao/UserDaoJdbc.java
@@ -1,0 +1,81 @@
+package com.binghe.ch04.dao;
+
+import com.binghe.ch04.domain.User;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import javax.sql.DataSource;
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.dao.support.DataAccessUtils;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.PreparedStatementCreator;
+import org.springframework.jdbc.core.ResultSetExtractor;
+import org.springframework.jdbc.core.RowMapper;
+
+public class UserDaoJdbc implements UserDao{
+
+    private JdbcTemplate jdbcTemplate;
+
+    public UserDaoJdbc(DataSource dataSource) {
+        this.jdbcTemplate = new JdbcTemplate(dataSource);
+    }
+
+    @Override
+    public void add(User user) {
+        jdbcTemplate.update("insert into users(id, name, password) values(?, ?, ?)", user.getId(), user.getName(), user.getPassword());
+    }
+
+    @Override
+    public User get(String id) {
+        return jdbcTemplate.query("select * from users where id = ?", (rs, rowNum) -> {
+            User user = new User();
+            user.setId(rs.getString("id"));
+            user.setName(rs.getString("name"));
+            user.setPassword(rs.getString("password"));
+            return user;
+        }, id)
+            .stream()
+            .findAny()
+            .orElseThrow(() -> new EmptyResultDataAccessException(1));
+    }
+
+    @Override
+    public List<User> getAll() {
+        return jdbcTemplate.query("select * from users order by id",
+            new RowMapper<User>() {
+                @Override
+                public User mapRow(ResultSet resultSet, int i) throws SQLException {
+                    User user = new User();
+                    user.setId(resultSet.getString("id"));
+                    user.setName(resultSet.getString("name"));
+                    user.setPassword(resultSet.getString("password"));
+                    return user;
+                }
+            });
+    }
+
+    @Override
+    public void deleteAll() {
+        jdbcTemplate.update(new PreparedStatementCreator() {
+            @Override
+            public PreparedStatement createPreparedStatement(
+                Connection connection) throws SQLException {
+                return connection.prepareStatement("delete from users");
+            }
+        });
+    }
+
+    @Override
+    public int getCount() {
+        return jdbcTemplate.query("select count(*) from users", new ResultSetExtractor<Integer>() {
+            @Override
+            public Integer extractData(ResultSet resultSet) throws SQLException, DataAccessException {
+                resultSet.next();
+                return resultSet.getInt(1);
+            }
+        });
+    }
+}

--- a/src/main/java/com/binghe/ch04/domain/User.java
+++ b/src/main/java/com/binghe/ch04/domain/User.java
@@ -1,0 +1,40 @@
+package com.binghe.ch04.domain;
+
+public class User {
+    private String id;
+    private String name;
+    private String password;
+
+    public User() {
+    }
+
+    public User(String id, String name, String password) {
+        this.id = id;
+        this.name = name;
+        this.password = password;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/src/test/java/com/binghe/ch04/dao/UserDaoTest.java
+++ b/src/test/java/com/binghe/ch04/dao/UserDaoTest.java
@@ -1,0 +1,119 @@
+package com.binghe.ch04.dao;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.binghe.ch04.DaoFactory;
+import com.binghe.ch04.domain.User;
+import java.sql.SQLException;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.support.SQLErrorCodeSQLExceptionTranslator;
+import org.springframework.jdbc.support.SQLExceptionTranslator;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = DaoFactory.class)
+class UserDaoTest {
+
+    @Autowired
+    private UserDao userDao;
+
+    @Autowired
+    private DataSource dataSource;
+
+    @Test
+    void sqlExceptionTranslate() {
+        userDao.deleteAll();
+
+        User user1 = new User("mark", "binghe", "password");
+
+        try {
+            userDao.add(user1);
+            userDao.add(user1);
+        } catch (DuplicateKeyException e) {
+            SQLException sqlEx = (SQLException) e.getRootCause();
+            SQLExceptionTranslator set = new SQLErrorCodeSQLExceptionTranslator(dataSource);
+//            System.out.println(set.translate(null, null, sqlEx));
+            assertThat(set.translate(null, null, sqlEx)).isInstanceOf(DuplicateKeyException.class);
+        }
+    }
+
+    @Test
+    void addAndGet() {
+        userDao.deleteAll();
+        assertThat(userDao.getCount()).isEqualTo(0);
+
+        User user1 = new User("mark", "binghe", "password");
+        User user2 = new User("pika", "jiwoo", "password");
+
+        userDao.add(user1);
+        userDao.add(user2);
+        assertThat(userDao.getCount()).isEqualTo(2);
+
+        User foundUser1 = userDao.get(user1.getId());
+        User foundUser2 = userDao.get(user2.getId());
+
+        assertAll(
+            () -> assertThat(foundUser1.getId()).isEqualTo(user1.getId()),
+            () -> assertThat(foundUser1.getName()).isEqualTo(user1.getName()),
+            () -> assertThat(foundUser1.getPassword()).isEqualTo(user1.getPassword()),
+            () -> assertThat(foundUser2.getId()).isEqualTo(user2.getId()),
+            () -> assertThat(foundUser2.getName()).isEqualTo(user2.getName()),
+            () -> assertThat(foundUser2.getPassword()).isEqualTo(user2.getPassword())
+        );
+    }
+
+    @DisplayName("get 실패 테스트")
+    @Test
+    void get_negative() {
+        userDao.deleteAll();
+        assertThat(userDao.getCount()).isEqualTo(0);
+
+        assertThatThrownBy(() -> userDao.get("0"))
+            .isInstanceOf(EmptyResultDataAccessException.class);
+    }
+
+    @Test
+    public void deteleAll() {
+        User user1 = new User("binghe", "홍길동", "1234");
+        User user2 = new User("toby", "토비", "4567");
+
+        userDao.deleteAll();
+        assertThat(userDao.getCount()).isEqualTo(0);
+
+        userDao.add(user1);
+        userDao.deleteAll();
+        assertThat(userDao.getCount()).isEqualTo(0);
+    }
+
+    @Test
+    public void getCount() {
+        User user1 = new User("binghe", "홍길동", "1234");
+        User user2 = new User("toby", "토비", "4567");
+        User user3 = new User("java", "자바", "8913");
+
+        // 테스트 1
+        userDao.deleteAll();
+        assertThat(userDao.getCount()).isEqualTo(0);
+
+        // 테스트 2
+        userDao.add(user1);
+        assertThat(userDao.getCount()).isEqualTo(1);
+
+        // 테스트 3
+        userDao.add(user2);
+        assertThat(userDao.getCount()).isEqualTo(2);
+
+        // 테스트 4
+        userDao.add(user3);
+        assertThat(userDao.getCount()).isEqualTo(3);
+    }
+}


### PR DESCRIPTION
미션 구현하는데 정신 없다보니 이제야 제출하네요..ㅎ 5장은 늦지 않게 제출해보도록 할게요~~

이번 장에선 스프링에서 어떻게 예외를 처리하는지 알 수 있어서 좋았습니다!

또한, 자바 예외 처리 전략에 대한 내용도 너무 좋았어요!!

그중에서도 특히 `DataAccessException`와 관련된 내용이 인상 깊었습니다~

> [토비의 스프링 4장 정리 내용](https://github.com/binghe819/TIL/blob/master/Spring/%ED%86%A0%EB%B9%84%EC%9D%98%20%EC%8A%A4%ED%94%84%EB%A7%81/4%EC%9E%A5%20%EC%98%88%EC%99%B8.md)

<br>

## DataAccessException

🤔 왜 스프링은 모든 예외를 DataAccessException으로 포장하고 있는 것일까?
1. SQLException의 호환성 문제
* DB마다 에러의 종류와 원인이 다르기에 스프링은 대부분 DB의 예외를 모두 DataAccessException에 담고 추상화 시켰다.
* 즉, 각각의 DB 에러 코드를 모두 비슷한 것들끼리 매핑시켜놓았다.
2. 데이터 엑세스 기술 예외 호환성 문제
* 데이터 액세스 기술(JDBC, JPA, 하이버네이트)마다 발생시키는 예외가 모두 다르다. 
* 스프링은 DataAccessException을 통해 이러한 예외를 모*두 통합시키고 추상화시켰다.
3. 체크 예외인 SQLException을 언체크 예외로 변경하기 위함.

> 가장 중요한 점은, `DB 회사별 기술과의 분리`와 `데이터 액세스 기술과의 분리`를 위해 `DataAccessException`을 했다는 것이다.
> 
> 이로 인해, 인터페이스 사용, 런타임 예외 전환과 함께 DataAccessException을 사용하면 데이터 엑세스 기술과 DAO의 구현은 독립적으로 구현할 수 있다.

<br>

## DataAccessException 주의 사항
> 각 기술별로 호환성을 100프로 장담할 수 없다.

* `DuplicateKeyException`은 아직까지 JDBC를 이용하는 경우에만 발생한다.
  * 하이버네이트나 JPA의 경우 다른 예외가 던져진다.
* 그 이유는 `SQLException`에 담긴 DB 에러 코드를 바로 해석하는 JDBC와 달리, JPA나 하이버네이트등은 각 기술이 재정의한 예외를 가져와 스프링이 최종적으로 `DataAccessException`으로 변환하는데, DB의 에러 코드와 달리 이런 예외들은 세분화되어 있지 않기 때문이라고한다.
  * ex. 하이버네이트에서 중복 키의 경우 `ConstraintViolationException`을 발생시킨다. 스프링은 이를 `DuplicateKeyException`의 상위 클래스인 `DataIntegrityViolationException`으로 변환시킨다.

<br>

## Checked냐? Unchecked냐?
> 이 부분은 정리를 하려고 했는데 웨지가 잘 정리를 해둬서 일단은 그냥 둘게요ㅎㅎ 
>
> 공부하여 새로운 인사이트가 생긴다면 여기다 올리겠습니다 :) 


