### PR TITLE
[고양이조] 케빈 5장 PR 제출합니다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,11 @@ dependencies {
     implementation group: 'cglib', name: 'cglib', version: '3.3.0'
     implementation group: 'mysql', name: 'mysql-connector-java', version: '8.0.24'
 
+    implementation group: 'javax.activation', name: 'activation', version: '1.1.1'
+    implementation group: 'com.sun.mail', name: 'javax.mail', version: '1.6.2'
+
+    implementation group: 'org.springframework', name: 'spring-context-support', version: '3.0.7.RELEASE'
+
     testImplementation group: 'org.springframework', name: 'spring-test', version: '5.3.7'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'
     testCompile("org.assertj:assertj-core:3.11.1")

--- a/src/main/java/springbook/dao/UserDao.java
+++ b/src/main/java/springbook/dao/UserDao.java
@@ -15,4 +15,6 @@ public interface UserDao {
     public int getCount();
 
     public List<User> getAll();
+
+    void update(User user1);
 }

--- a/src/main/java/springbook/dao/UserDaoJdbc.java
+++ b/src/main/java/springbook/dao/UserDaoJdbc.java
@@ -23,12 +23,13 @@ public class UserDaoJdbc implements UserDao {
             user.setLevel(Level.of(rs.getInt("level")));
             user.setLogin(rs.getInt("login"));
             user.setRecommend(rs.getInt("recommend"));
+            user.setEmail(rs.getString("email"));
             return user;
         }
     };
 
     public void addUser(User user) {
-        this.jdbcTemplate.update("insert into users(id, name, password, level, login, recommend) values(?,?,?,?,?,?)", user.getId(), user.getName(), user.getPassword(), user.getLevel().getValue(), user.getLogin(), user.getRecommend());
+        this.jdbcTemplate.update("insert into users(id, name, password, email, level, login, recommend) values(?,?,?,?,?,?,?)", user.getId(), user.getName(), user.getPassword(), user.getEmail(), user.getLevel().getValue(), user.getLogin(), user.getRecommend());
     }
 
     public User getUser(String id) {
@@ -53,7 +54,7 @@ public class UserDaoJdbc implements UserDao {
 
     @Override
     public void update(User user) {
-        jdbcTemplate.update("update users set name = ?, password = ?, level = ?, login = ?, recommend = ? where id = ?",
-                user.getName(), user.getPassword(), user.getLevel().getValue(), user.getLogin(), user.getRecommend(), user.getId());
+        jdbcTemplate.update("update users set name = ?, password = ?, email = ?, level = ?, login = ?, recommend = ? where id = ?",
+                user.getName(), user.getPassword(), user.getEmail(), user.getLevel().getValue(), user.getLogin(), user.getRecommend(), user.getId());
     }
 }

--- a/src/main/java/springbook/dao/UserDaoJdbc.java
+++ b/src/main/java/springbook/dao/UserDaoJdbc.java
@@ -2,6 +2,7 @@ package springbook.dao;
 
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
+import springbook.domain.user.Level;
 import springbook.domain.user.User;
 
 import javax.sql.DataSource;
@@ -19,12 +20,15 @@ public class UserDaoJdbc implements UserDao {
             user.setId(rs.getString("id"));
             user.setName(rs.getString("name"));
             user.setPassword(rs.getString("password"));
+            user.setLevel(Level.of(rs.getInt("level")));
+            user.setLogin(rs.getInt("login"));
+            user.setRecommend(rs.getInt("recommend"));
             return user;
         }
     };
 
     public void addUser(User user) {
-        this.jdbcTemplate.update("insert into users(id, name, password) values(?,?,?)", user.getId(), user.getName(), user.getPassword());
+        this.jdbcTemplate.update("insert into users(id, name, password, level, login, recommend) values(?,?,?,?,?,?)", user.getId(), user.getName(), user.getPassword(), user.getLevel().getValue(), user.getLogin(), user.getRecommend());
     }
 
     public User getUser(String id) {
@@ -45,5 +49,11 @@ public class UserDaoJdbc implements UserDao {
 
     public List<User> getAll() {
         return jdbcTemplate.query("select * from users order by id", rowMapper);
+    }
+
+    @Override
+    public void update(User user) {
+        jdbcTemplate.update("update users set name = ?, password = ?, level = ?, login = ?, recommend = ? where id = ?",
+                user.getName(), user.getPassword(), user.getLevel().getValue(), user.getLogin(), user.getRecommend(), user.getId());
     }
 }

--- a/src/main/java/springbook/domain/user/Level.java
+++ b/src/main/java/springbook/domain/user/Level.java
@@ -1,0 +1,26 @@
+package springbook.domain.user;
+
+import java.util.Arrays;
+
+public enum Level {
+    BASIC(1),
+    SILVER(2),
+    GOLD(3);
+
+    private final int value;
+
+    Level(int value) {
+        this.value = value;
+    }
+
+    public static Level of(int value) {
+        return Arrays.stream(Level.values())
+                .filter(t -> t.value == value)
+                .findFirst()
+                .orElseThrow(IllegalArgumentException::new);
+    }
+
+    public int getValue() {
+        return value;
+    }
+}

--- a/src/main/java/springbook/domain/user/Level.java
+++ b/src/main/java/springbook/domain/user/Level.java
@@ -3,14 +3,16 @@ package springbook.domain.user;
 import java.util.Arrays;
 
 public enum Level {
-    BASIC(1),
-    SILVER(2),
-    GOLD(3);
+    GOLD(3, null),
+    SILVER(2, Level.GOLD),
+    BASIC(1, Level.SILVER);
 
     private final int value;
+    private final Level next;
 
-    Level(int value) {
+    Level(int value, Level next) {
         this.value = value;
+        this.next = next;
     }
 
     public static Level of(int value) {
@@ -22,5 +24,9 @@ public enum Level {
 
     public int getValue() {
         return value;
+    }
+
+    public Level getNext() {
+        return next;
     }
 }

--- a/src/main/java/springbook/domain/user/User.java
+++ b/src/main/java/springbook/domain/user/User.java
@@ -7,14 +7,20 @@ public class User {
     private String id;
     private String name;
     private String password;
+    private Level level;
+    private int login;
+    private int recommend;
 
     public User() {
     }
 
-    public User(String id, String name, String password) {
+    public User(String id, String name, String password, Level level, int login, int recommend) {
         this.id = id;
         this.name = name;
         this.password = password;
+        this.level = level;
+        this.login = login;
+        this.recommend = recommend;
     }
 
     public String getId() {
@@ -41,16 +47,40 @@ public class User {
         this.password = password;
     }
 
+    public Level getLevel() {
+        return level;
+    }
+
+    public void setLevel(Level level) {
+        this.level = level;
+    }
+
+    public int getLogin() {
+        return login;
+    }
+
+    public void setLogin(int login) {
+        this.login = login;
+    }
+
+    public int getRecommend() {
+        return recommend;
+    }
+
+    public void setRecommend(int recommend) {
+        this.recommend = recommend;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         User user = (User) o;
-        return Objects.equals(id, user.id) && Objects.equals(name, user.name) && Objects.equals(password, user.password);
+        return login == user.login && recommend == user.recommend && Objects.equals(id, user.id) && Objects.equals(name, user.name) && Objects.equals(password, user.password) && level == user.level;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, password);
+        return Objects.hash(id, name, password, level, login, recommend);
     }
 }

--- a/src/main/java/springbook/domain/user/User.java
+++ b/src/main/java/springbook/domain/user/User.java
@@ -1,5 +1,6 @@
 package springbook.domain.user;
 
+import java.util.Date;
 import java.util.Objects;
 
 public class User {
@@ -10,6 +11,8 @@ public class User {
     private Level level;
     private int login;
     private int recommend;
+
+    private Date lastUpgraded;
 
     public User() {
     }
@@ -69,6 +72,23 @@ public class User {
 
     public void setRecommend(int recommend) {
         this.recommend = recommend;
+    }
+
+    public Date getLastUpgraded() {
+        return lastUpgraded;
+    }
+
+    public void setLastUpgraded(Date lastUpgraded) {
+        this.lastUpgraded = lastUpgraded;
+    }
+
+    public void upgradeLevel() {
+        Level next = level.getNext();
+        if (next == null) {
+            throw new IllegalArgumentException("cannot upgrae this level " + level);
+        }
+        level = next;
+        lastUpgraded = new Date();
     }
 
     @Override

--- a/src/main/java/springbook/domain/user/User.java
+++ b/src/main/java/springbook/domain/user/User.java
@@ -8,6 +8,7 @@ public class User {
     private String id;
     private String name;
     private String password;
+    private String email;
     private Level level;
     private int login;
     private int recommend;
@@ -17,10 +18,11 @@ public class User {
     public User() {
     }
 
-    public User(String id, String name, String password, Level level, int login, int recommend) {
+    public User(String id, String name, String password, String email, Level level, int login, int recommend) {
         this.id = id;
         this.name = name;
         this.password = password;
+        this.email = email;
         this.level = level;
         this.login = login;
         this.recommend = recommend;
@@ -82,6 +84,14 @@ public class User {
         this.lastUpgraded = lastUpgraded;
     }
 
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
     public void upgradeLevel() {
         Level next = level.getNext();
         if (next == null) {
@@ -96,11 +106,11 @@ public class User {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         User user = (User) o;
-        return login == user.login && recommend == user.recommend && Objects.equals(id, user.id) && Objects.equals(name, user.name) && Objects.equals(password, user.password) && level == user.level;
+        return login == user.login && recommend == user.recommend && Objects.equals(id, user.id) && Objects.equals(name, user.name) && Objects.equals(password, user.password) && Objects.equals(email, user.email) && level == user.level && Objects.equals(lastUpgraded, user.lastUpgraded);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, password, level, login, recommend);
+        return Objects.hash(id, name, password, email, level, login, recommend, lastUpgraded);
     }
 }

--- a/src/main/java/springbook/service/DummyMailSender.java
+++ b/src/main/java/springbook/service/DummyMailSender.java
@@ -1,0 +1,18 @@
+package springbook.service;
+
+import org.springframework.mail.MailException;
+import org.springframework.mail.MailSender;
+import org.springframework.mail.SimpleMailMessage;
+
+public class DummyMailSender implements MailSender {
+
+    @Override
+    public void send(SimpleMailMessage simpleMessage) throws MailException {
+        System.out.println(simpleMessage.getFrom());
+        System.out.println(simpleMessage.getText());
+    }
+
+    @Override
+    public void send(SimpleMailMessage[] simpleMessages) throws MailException {
+    }
+}

--- a/src/main/java/springbook/service/NormalUserLevelUpgradePolicy.java
+++ b/src/main/java/springbook/service/NormalUserLevelUpgradePolicy.java
@@ -1,0 +1,29 @@
+package springbook.service;
+
+import springbook.domain.user.Level;
+import springbook.domain.user.User;
+
+public class NormalUserLevelUpgradePolicy implements UserLevelUpgradePolicy {
+
+    public static final int MIN_LOGCOUNT_FOR_SILVER = 50;
+    public static final int MIN_RECCOMEND_FOR_GOLD = 30;
+
+    @Override
+    public boolean canUpgradeLevel(User user) {
+        if (user.getLevel() == Level.BASIC) {
+            return user.getLogin() >= MIN_LOGCOUNT_FOR_SILVER;
+        }
+        if (user.getLevel() == Level.SILVER) {
+            return user.getRecommend() >= MIN_RECCOMEND_FOR_GOLD;
+        }
+        if (user.getLevel() == Level.GOLD) {
+            return false;
+        }
+        throw new IllegalArgumentException("unknown level");
+    }
+
+    @Override
+    public void upgradeLevel(User user) {
+        user.upgradeLevel();
+    }
+}

--- a/src/main/java/springbook/service/TestUserService.java
+++ b/src/main/java/springbook/service/TestUserService.java
@@ -1,0 +1,20 @@
+package springbook.service;
+
+import springbook.domain.user.User;
+
+public class TestUserService extends UserService {
+
+    private String id;
+
+    public TestUserService(String id) {
+        this.id = id;
+    }
+
+    @Override
+    protected void upgradeLevel(User user) {
+        if (user.getId().equals(this.id)) {
+            throw new IllegalArgumentException();
+        }
+        super.upgradeLevel(user);
+    }
+}

--- a/src/main/java/springbook/service/UserLevelUpgradePolicy.java
+++ b/src/main/java/springbook/service/UserLevelUpgradePolicy.java
@@ -1,0 +1,10 @@
+package springbook.service;
+
+import springbook.domain.user.User;
+
+public interface UserLevelUpgradePolicy {
+
+    boolean canUpgradeLevel(User user);
+
+    void upgradeLevel(User user);
+}

--- a/src/main/java/springbook/service/UserService.java
+++ b/src/main/java/springbook/service/UserService.java
@@ -2,13 +2,37 @@ package springbook.service;
 
 import org.springframework.stereotype.Service;
 import springbook.dao.UserDao;
+import springbook.domain.user.Level;
+import springbook.domain.user.User;
 
 @Service
 public class UserService {
 
     private UserDao userDao;
+    private UserLevelUpgradePolicy userLevelUpgradePolicy;
 
     public void setUserDao(UserDao userDao) {
         this.userDao = userDao;
+    }
+
+    public void setUserLevelUpgradePolicy(UserLevelUpgradePolicy userLevelUpgradePolicy) {
+        this.userLevelUpgradePolicy = userLevelUpgradePolicy;
+    }
+
+    public void upgradeLevels() {
+        userDao.getAll()
+                .forEach(user -> {
+                    if (userLevelUpgradePolicy.canUpgradeLevel(user)) {
+                        userLevelUpgradePolicy.upgradeLevel(user);
+                        userDao.update(user);
+                    }
+                });
+    }
+
+    public void add(User user) {
+        if (user.getLevel() == null) {
+            user.setLevel(Level.BASIC);
+        }
+        userDao.addUser(user);
     }
 }

--- a/src/main/java/springbook/service/UserService.java
+++ b/src/main/java/springbook/service/UserService.java
@@ -1,32 +1,58 @@
 package springbook.service;
 
+import org.springframework.jdbc.datasource.DataSourceUtils;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import springbook.dao.UserDao;
 import springbook.domain.user.Level;
 import springbook.domain.user.User;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
 
 @Service
 public class UserService {
 
     private UserDao userDao;
     private UserLevelUpgradePolicy userLevelUpgradePolicy;
+    private DataSource dataSource;
 
     public void setUserDao(UserDao userDao) {
         this.userDao = userDao;
+    }
+
+    public void setDataSource(DataSource dataSource) {
+        this.dataSource = dataSource;
     }
 
     public void setUserLevelUpgradePolicy(UserLevelUpgradePolicy userLevelUpgradePolicy) {
         this.userLevelUpgradePolicy = userLevelUpgradePolicy;
     }
 
-    public void upgradeLevels() {
-        userDao.getAll()
-                .forEach(user -> {
-                    if (userLevelUpgradePolicy.canUpgradeLevel(user)) {
-                        userLevelUpgradePolicy.upgradeLevel(user);
-                        userDao.update(user);
-                    }
-                });
+    public void upgradeLevels() throws SQLException {
+        TransactionSynchronizationManager.initSynchronization();
+        Connection connection = DataSourceUtils.getConnection(dataSource);
+        connection.setAutoCommit(false);
+        try {
+            userDao.getAll()
+                    .forEach(this::upgradeLevel);
+            connection.commit();
+        } catch (Exception exception) {
+            connection.rollback();
+            throw exception;
+        } finally {
+            DataSourceUtils.releaseConnection(connection, dataSource);
+            TransactionSynchronizationManager.unbindResource(this.dataSource);
+            TransactionSynchronizationManager.clearSynchronization();
+        }
+    }
+
+    protected void upgradeLevel(User user) {
+        if (userLevelUpgradePolicy.canUpgradeLevel(user)) {
+            userLevelUpgradePolicy.upgradeLevel(user);
+            userDao.update(user);
+        }
     }
 
     public void add(User user) {

--- a/src/main/java/springbook/service/UserService.java
+++ b/src/main/java/springbook/service/UserService.java
@@ -1,0 +1,14 @@
+package springbook.service;
+
+import org.springframework.stereotype.Service;
+import springbook.dao.UserDao;
+
+@Service
+public class UserService {
+
+    private UserDao userDao;
+
+    public void setUserDao(UserDao userDao) {
+        this.userDao = userDao;
+    }
+}

--- a/src/main/java/springbook/service/UserService.java
+++ b/src/main/java/springbook/service/UserService.java
@@ -1,5 +1,7 @@
 package springbook.service;
 
+import org.springframework.mail.MailSender;
+import org.springframework.mail.SimpleMailMessage;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionStatus;
@@ -8,14 +10,13 @@ import springbook.dao.UserDao;
 import springbook.domain.user.Level;
 import springbook.domain.user.User;
 
-import java.sql.SQLException;
-
 @Service
 public class UserService {
 
     private UserDao userDao;
     private UserLevelUpgradePolicy userLevelUpgradePolicy;
     private PlatformTransactionManager transactionManager;
+    private MailSender mailSender;
 
     public void setUserDao(UserDao userDao) {
         this.userDao = userDao;
@@ -29,7 +30,11 @@ public class UserService {
         this.transactionManager = transactionManager;
     }
 
-    public void upgradeLevels() throws SQLException {
+    public void setMailSender(MailSender mailSender) {
+        this.mailSender = mailSender;
+    }
+
+    public void upgradeLevels() {
         TransactionStatus transaction = transactionManager.getTransaction(new DefaultTransactionDefinition());
         try {
             userDao.getAll()
@@ -45,7 +50,17 @@ public class UserService {
         if (userLevelUpgradePolicy.canUpgradeLevel(user)) {
             userLevelUpgradePolicy.upgradeLevel(user);
             userDao.update(user);
+            sendEmail(user);
         }
+    }
+
+    private void sendEmail(User user) {
+        SimpleMailMessage simpleMailMessage = new SimpleMailMessage();
+        simpleMailMessage.setTo(user.getEmail());
+        simpleMailMessage.setFrom("useradmin@ksug.org");
+        simpleMailMessage.setSubject("Upgrade 안내");
+        simpleMailMessage.setText("사용자님의 등급이 " + user.getLevel().name());
+        mailSender.send(simpleMailMessage);
     }
 
     public void add(User user) {

--- a/src/main/resources/applicationContext.xml
+++ b/src/main/resources/applicationContext.xml
@@ -6,6 +6,9 @@
     <bean id="userDaoJdbc" class="springbook.dao.UserDaoJdbc">
         <property name="dataSource" ref="dataSource"/>
     </bean>
+    <bean id="userService" class="springbook.service.UserService">
+        <property name="userDao" ref="userDaoJdbc"/>
+    </bean>
     <bean id="dataSource" class="org.springframework.jdbc.datasource.SimpleDriverDataSource">
         <property name="driverClass" value="com.mysql.cj.jdbc.Driver"/>
         <property name="url" value="jdbc:mysql://localhost:13306/tobi"/>

--- a/src/main/resources/applicationContext.xml
+++ b/src/main/resources/applicationContext.xml
@@ -10,6 +10,10 @@
         <property name="userDao" ref="userDaoJdbc"/>
         <property name="userLevelUpgradePolicy" ref="userLevelUpgradePolicy"/>
         <property name="transactionManager" ref="transactionManager"/>
+        <property name="mailSender" ref="mailSender"/>
+    </bean>
+    <bean id="mailSender" class="org.springframework.mail.javamail.JavaMailSenderImpl">
+        <property name="host" value="mail.server.com"/>
     </bean>
     <bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
         <property name="dataSource" ref="dataSource"/>

--- a/src/main/resources/applicationContext.xml
+++ b/src/main/resources/applicationContext.xml
@@ -9,6 +9,7 @@
     <bean id="userService" class="springbook.service.UserService">
         <property name="userDao" ref="userDaoJdbc"/>
     </bean>
+    <bean id="userLevelUpgradePolicy" class="springbook.service.NormalUserLevelUpgradePolicy"/>
     <bean id="dataSource" class="org.springframework.jdbc.datasource.SimpleDriverDataSource">
         <property name="driverClass" value="com.mysql.cj.jdbc.Driver"/>
         <property name="url" value="jdbc:mysql://localhost:13306/tobi"/>

--- a/src/main/resources/applicationContext.xml
+++ b/src/main/resources/applicationContext.xml
@@ -8,6 +8,8 @@
     </bean>
     <bean id="userService" class="springbook.service.UserService">
         <property name="userDao" ref="userDaoJdbc"/>
+        <property name="userLevelUpgradePolicy" ref="userLevelUpgradePolicy"/>
+        <property name="dataSource" ref="dataSource"/>
     </bean>
     <bean id="userLevelUpgradePolicy" class="springbook.service.NormalUserLevelUpgradePolicy"/>
     <bean id="dataSource" class="org.springframework.jdbc.datasource.SimpleDriverDataSource">

--- a/src/main/resources/applicationContext.xml
+++ b/src/main/resources/applicationContext.xml
@@ -9,6 +9,9 @@
     <bean id="userService" class="springbook.service.UserService">
         <property name="userDao" ref="userDaoJdbc"/>
         <property name="userLevelUpgradePolicy" ref="userLevelUpgradePolicy"/>
+        <property name="transactionManager" ref="transactionManager"/>
+    </bean>
+    <bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
         <property name="dataSource" ref="dataSource"/>
     </bean>
     <bean id="userLevelUpgradePolicy" class="springbook.service.NormalUserLevelUpgradePolicy"/>

--- a/src/main/resources/test-applicationContext.xml
+++ b/src/main/resources/test-applicationContext.xml
@@ -10,7 +10,9 @@
         <property name="userDao" ref="userDaoJdbc"/>
         <property name="userLevelUpgradePolicy" ref="userLevelUpgradePolicy"/>
         <property name="transactionManager" ref="transactionManager"/>
+        <property name="mailSender" ref="mailSender"/>
     </bean>
+    <bean id="mailSender" class="springbook.service.DummyMailSender"/>
     <bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
         <property name="dataSource" ref="dataSource"/>
     </bean>

--- a/src/main/resources/test-applicationContext.xml
+++ b/src/main/resources/test-applicationContext.xml
@@ -6,6 +6,9 @@
     <bean id="userDaoJdbc" class="springbook.dao.UserDaoJdbc">
         <property name="dataSource" ref="dataSource"/>
     </bean>
+    <bean id="userService" class="springbook.service.UserService">
+        <property name="userDao" ref="userDaoJdbc"/>
+    </bean>
     <bean id="dataSource" class="org.springframework.jdbc.datasource.SimpleDriverDataSource">
         <property name="driverClass" value="com.mysql.cj.jdbc.Driver"/>
         <property name="url" value="jdbc:mysql://localhost:13306/testdb"/>

--- a/src/main/resources/test-applicationContext.xml
+++ b/src/main/resources/test-applicationContext.xml
@@ -9,6 +9,7 @@
     <bean id="userService" class="springbook.service.UserService">
         <property name="userDao" ref="userDaoJdbc"/>
         <property name="userLevelUpgradePolicy" ref="userLevelUpgradePolicy"/>
+        <property name="dataSource" ref="dataSource"/>
     </bean>
     <bean id="userLevelUpgradePolicy" class="springbook.service.NormalUserLevelUpgradePolicy"/>
     <bean id="dataSource" class="org.springframework.jdbc.datasource.SimpleDriverDataSource">

--- a/src/main/resources/test-applicationContext.xml
+++ b/src/main/resources/test-applicationContext.xml
@@ -8,7 +8,9 @@
     </bean>
     <bean id="userService" class="springbook.service.UserService">
         <property name="userDao" ref="userDaoJdbc"/>
+        <property name="userLevelUpgradePolicy" ref="userLevelUpgradePolicy"/>
     </bean>
+    <bean id="userLevelUpgradePolicy" class="springbook.service.NormalUserLevelUpgradePolicy"/>
     <bean id="dataSource" class="org.springframework.jdbc.datasource.SimpleDriverDataSource">
         <property name="driverClass" value="com.mysql.cj.jdbc.Driver"/>
         <property name="url" value="jdbc:mysql://localhost:13306/testdb"/>

--- a/src/main/resources/test-applicationContext.xml
+++ b/src/main/resources/test-applicationContext.xml
@@ -9,6 +9,9 @@
     <bean id="userService" class="springbook.service.UserService">
         <property name="userDao" ref="userDaoJdbc"/>
         <property name="userLevelUpgradePolicy" ref="userLevelUpgradePolicy"/>
+        <property name="transactionManager" ref="transactionManager"/>
+    </bean>
+    <bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
         <property name="dataSource" ref="dataSource"/>
     </bean>
     <bean id="userLevelUpgradePolicy" class="springbook.service.NormalUserLevelUpgradePolicy"/>

--- a/src/test/java/springbook/dao/UserDaoJdbcTest.java
+++ b/src/test/java/springbook/dao/UserDaoJdbcTest.java
@@ -44,9 +44,9 @@ class UserDaoJdbcTest {
     void setUp() {
         System.out.println(this);
         System.out.println(this.applicationContext);
-        user1 = new User("gyumee", "park", "springno1", Level.BASIC, 1, 0);
-        user2 = new User("leegw700", "lee", "springno2", Level.SILVER, 55, 10);
-        user3 = new User("bumjin", "박범진", "springno3", Level.GOLD, 100, 40);
+        user1 = new User("gyumee", "park", "springno1", "abc@naver.com", Level.BASIC, 1, 0);
+        user2 = new User("leegw700", "lee", "springno2", "abafddac@naver.com", Level.SILVER, 55, 10);
+        user3 = new User("bumjin", "박범진", "springno3", "abc11111@naver.com", Level.GOLD, 100, 40);
     }
 
     @Test

--- a/src/test/java/springbook/dao/UserDaoJdbcTest.java
+++ b/src/test/java/springbook/dao/UserDaoJdbcTest.java
@@ -12,6 +12,7 @@ import org.springframework.jdbc.support.SQLErrorCodeSQLExceptionTranslator;
 import org.springframework.jdbc.support.SQLExceptionTranslator;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import springbook.domain.user.Level;
 import springbook.domain.user.User;
 
 import javax.sql.DataSource;
@@ -43,9 +44,9 @@ class UserDaoJdbcTest {
     void setUp() {
         System.out.println(this);
         System.out.println(this.applicationContext);
-        user1 = new User("gyumee", "park", "springno1");
-        user2 = new User("leegw700", "lee", "springno2");
-        user3 = new User("bumjin", "박범진", "springno3");
+        user1 = new User("gyumee", "park", "springno1", Level.BASIC, 1, 0);
+        user2 = new User("leegw700", "lee", "springno2", Level.SILVER, 55, 10);
+        user3 = new User("bumjin", "박범진", "springno3", Level.GOLD, 100, 40);
     }
 
     @Test
@@ -58,12 +59,10 @@ class UserDaoJdbcTest {
         assertThat(userDao.getCount()).isEqualTo(2);
 
         User user1get = userDao.getUser(user1.getId());
-        assertThat(user1get.getName()).isEqualTo(user1.getName());
-        assertThat(user1get.getPassword()).isEqualTo(user1.getPassword());
+        assertThat(user1get).isEqualTo(user1);
 
         User user2get = userDao.getUser(user2.getId());
-        assertThat(user2get.getName()).isEqualTo(user2.getName());
-        assertThat(user2get.getPassword()).isEqualTo(user2.getPassword());
+        assertThat(user2get).isEqualTo(user2);
     }
 
     @Test
@@ -128,5 +127,25 @@ class UserDaoJdbcTest {
             SQLExceptionTranslator set = new SQLErrorCodeSQLExceptionTranslator(this.dataSource);
             assertThat(set.translate(null, null, sqlEx)).isInstanceOf(DataAccessException.class);
         }
+    }
+
+    @Test
+    void update() {
+        userDao.deleteAll();
+        userDao.addUser(user1);
+        userDao.addUser(user2);
+
+        user1.setName("another user");
+        user1.setPassword("another pass");
+        user1.setLevel(Level.GOLD);
+        user1.setLogin(1000);
+        user1.setRecommend(999);
+
+        userDao.update(user1);
+        User user1Update = userDao.getUser(user1.getId());
+        User user2Get = userDao.getUser(user2.getId());
+
+        assertThat(user1Update.equals(user1)).isTrue();
+        assertThat(user2).isEqualTo(user2Get);
     }
 }

--- a/src/test/java/springbook/domain/user/UserTest.java
+++ b/src/test/java/springbook/domain/user/UserTest.java
@@ -1,0 +1,43 @@
+package springbook.domain.user;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+class UserTest {
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        user = new User();
+    }
+
+    @Test
+    void upgradeLevel() {
+        Level[] values = Level.values();
+        for (Level level : values) {
+            if (level.getNext() == null) {
+                continue;
+            }
+            user.setLevel(level);
+            user.upgradeLevel();
+            assertThat(user.getLevel()).isEqualTo(level.getNext());
+        }
+    }
+
+    @Test
+    void cannotUpgradeLevel() {
+        Level[] values = Level.values();
+        for (Level level : values) {
+            if (level.getNext() != null) {
+                continue;
+            }
+            user.setLevel(level);
+            assertThatCode(() -> user.upgradeLevel())
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+}

--- a/src/test/java/springbook/service/UserServiceTest.java
+++ b/src/test/java/springbook/service/UserServiceTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import springbook.dao.UserDao;
@@ -89,9 +90,9 @@ class UserServiceTest {
     void upgradeAllOrNothing() throws SQLException {
         UserService userService = new TestUserService(users.get(3).getId());
         userService.setUserDao(userDao);
-        userService.setDataSource(dataSource);
         userService.setUserLevelUpgradePolicy(new NormalUserLevelUpgradePolicy());
-
+        userService.setTransactionManager(new DataSourceTransactionManager(dataSource));
+        
         userDao.deleteAll();
         users.forEach(user -> userDao.addUser(user));
 

--- a/src/test/java/springbook/service/UserServiceTest.java
+++ b/src/test/java/springbook/service/UserServiceTest.java
@@ -1,0 +1,82 @@
+package springbook.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import springbook.dao.UserDao;
+import springbook.domain.user.Level;
+import springbook.domain.user.User;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration("classpath:/test-applicationContext.xml")
+class UserServiceTest {
+
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private UserDao userDao;
+
+    private List<User> users;
+
+    @BeforeEach
+    void setUp() {
+        users = Arrays.asList(
+                new User("bumjin", "a", "p1", Level.BASIC, 49, 0),
+                new User("joytouch", "b", "p2", Level.BASIC, 50, 0),
+                new User("erwins", "c", "p3", Level.SILVER, 60, 29),
+                new User("madnite1", "d", "p4", Level.SILVER, 60, 30),
+                new User("green", "e", "p5", Level.GOLD, 100, 100)
+        );
+    }
+
+    @Test
+    void upgradeLevels() {
+        userDao.deleteAll();
+        users.forEach(user -> userDao.addUser(user));
+
+        userService.upgradeLevels();
+
+        checkLevel(users.get(0), false);
+        checkLevel(users.get(1), true);
+        checkLevel(users.get(2), false);
+        checkLevel(users.get(3), true);
+        checkLevel(users.get(4), false);
+    }
+
+    private void checkLevel(User user, boolean isUpgraded) {
+        Level level = userDao.getUser(user.getId()).getLevel();
+        if (isUpgraded) {
+            assertThat(user.getLevel().getNext()).isEqualTo(level);
+        } else {
+            assertThat(user.getLevel()).isEqualTo(level);
+        }
+    }
+
+
+    @Test
+    void add() {
+        userDao.deleteAll();
+
+        User userWithLevel = users.get(4);
+        User userWithoutLevel = users.get(0);
+        userWithoutLevel.setLevel(null);
+
+        userService.add(userWithLevel);
+        userService.add(userWithoutLevel);
+
+        User userWithLevelRead = userDao.getUser(userWithLevel.getId());
+        User userWithoutLevelRead = userDao.getUser(userWithoutLevel.getId());
+
+        assertThat(userWithLevel.getLevel()).isEqualTo(userWithLevelRead.getLevel());
+        assertThat(userWithoutLevelRead.getLevel()).isEqualTo(Level.BASIC);
+    }
+}


### PR DESCRIPTION
* 학습 정리
* https://xlffm3.github.io/spring%20&%20spring%20boot/toby-spring-chapter5/

---

Transaction을 적용하기 위한 여정이 꽤나 흥미롭다.

* Jdbc의 경우 트랜잭션의 시작 선언은 autoCommit을 끄는 것이고, 경계 지정은 롤백이나 커밋 메서드를 호출하는 것이다.
* Dao가 JdbcTemplate을 사용하면 Connection을 직접 접근 및 제어하는 구조가 아니라 트랜잭션을 설정할 수 없다.
  * JdbcTemplate이 콜백을 사용해 작업을 처리할 때 커넥션을 알아서 만들고 닫기 때문.
  * 특히 Dao 메서드가 호출하는 JdbcTemplate의 메서드들은 호출할 때마다 매번 독립적인 트랜잭션을 생성하며, 작업 종료시 자동으로 커밋이 되버림. 각각의 메서드들이 트랜잭션에 협력이 불가능한 구조...
 * 트랜잭션을 사용하려면 결국 jdbcTemplate을 버리고 Dao가 datasource를 직접 사용해야함. (퇴보 1스택)

---

 * 그런데 트랜잭션에는 여러 개의 dao 메서드(쿼리)가 참여할 수 있음... 이는 결국 서비스 레이어에서 트랜잭션을 지정해줘야 함.
   * 결국 서비스가 DataSource를 가지고 커넥션을 생성한다음, 해당 커넥션으로 트랜잭션 경계를 설정해야함.
   * 기껏 dao와 service 분리했더니 다시 레이어간 경계가 모호해져버림 (퇴보 2스택)
* 문제는 로컬 트랜잭션(jdbc)에서는 트랜잭션이 커넥션에 종속되는 구조. 여러 dao 메서드들이 하나의 트랜잭션에 참여하려면, 모두 같은 커넥션을 공유해야 함.
  * 트랜잭션 경계를 설정하더라도 dao가 트랜잭션 선언에 사용된 커넥션이 아닌 다른 커넥션을 사용하면 트랜잭션 참여하는 것이 아니라 독립적인 트랜잭션을 생성하는 것.
  * 그럴려면 결국 서비스레이어에서 만든 커넥션을 dao 메서드들에게 파라미터로 건내줘야함.
  * 이는 userDao 인터페이스 시그니처가 변경됨을 의미. ``update(User)`` -> ``update(Connection, User)``
    * 문제는 jpa나 hibernate의 경우 트랜잭션 관리에 사용하는 리소스가 달라서 데이터 액세스 기술이 변경될 때마다 인터페이스 시그니처들이 함께 변경되어야 함 ``update(Connection, User)`` -> ``update(Session, User)``
    * 또한 트랜잭션 경계를 지정하는 서비스 레이어의 코드 또한 데이터 액세스 기술이 변경되면 함께 변경
    * 데이터 액세스 기술에 종속적이지 않으려고 userDao 인터페이스를 분리했는데, 결과적으로 데이터 액세스 기술에 종속되어버림 (퇴보 3스택)

---

* TransactionSynchronizationManager를 통해 트랜잭션 동기화 저장소에 DB 커넥션을 등록하고, jdcbTemplate은 동기화 저장소에 커넥션이 있는 경우 트랜잭션에 참여하고 아니라면 독립적인 트랜잭션을 타도록 개선.
  * 서비스레이어가 커넥션 자원을 파라미터로 dao에 전달하던 문제 해소, 인터페이스가 기술 종속적이던 문제 해결
* 근데 로컬 트랜잭션 한정이라 여러 db들이 참여하는 트랜잭션을 관리할수 없음...
  * 글로벌 트랜잭션을 관리할 수 있는 JTA API를 사용하면 됨 ! 짱짱맨!
  * 근데 로컬 트랜잭션을 사용할 때랑 jta를 사용할 때랑 서비스 코드가 달라지게 됨.
  * 특히 하이버네이트는 독자적인 트랜잭션 관리로 인해 커넥션이 아닌 세션을 씀
  * 인터페이스가 기술 종속적이지 않더라도 서비스 자체가 기술에 종속되버리는 문제 원점으로 회귀 (ㅠㅠ)

---

* 트랜잭션 경계 설정 코드는 대게 비슷한 패턴. 공통 부분을 추상화로 뽑아내면 하위 시스템이 변경되어도 사용자 측은 일관되게 트랜잭션 관련 기능을 사용할 수 있음.
* Spring은 hibernate, datasorurce, jta 등등 다양한 트랜잭션 경계설정 방식들의 추상화 인터페이스인 PlatformTransactionManager를 제공.
  * 이를 통해 드디어!!  원하는 데이터 액세스 기술 및 글로벌 or 로컬 방식에 따라 적합한 구현체를 di 방식을 통해 PlatformTransactionManager에 주입해주면 됨.
  * 데이터 액세스 기술이 변하더라도 서비스 코드는 변화가 없음. 즉 기술에 독립적이게 됨.
  * 기존에는 서비스 관리 로직 및 트랜잭션 관리 로직 등 두 가지 관심사가 산재했는데, 이를 통해 하나의 관심사만 가지게 되는 단일 책임 원칙을 달성하게됨.

---

예외적인 케이스가 아닌 이상 직접 트랜잭션 경계를 설정하기 보다는 @Transactional 애너테이션을 많이 쓰는데
간단한 이 애너테이션 이면에 이런 복잡한 사정이 있을줄은...