### PR TITLE
[M1칩조] 파즈 5장 PR 제출합니다.

### DIFF
--- a/5. 서비스 추상화.md
+++ b/5. 서비스 추상화.md
@@ -1,0 +1,20 @@
+# 5. 서비스 추상화
+
+JdbcTemplate은 하나의 템플릿 메소드 안에서 DataSource의 getConnection() 메소드를 호출해서 Connection 오브젝트를 가져오고, 작업을 마치면 Connection을 확실하게 닫아주고 템플릿 메소드를 빠져나온다.  
+
+Dao 메소드를 호출할 때 마다 새로운 트랜잭션이 만들어지는 구도일 시에 여러번 DB 업데이트를 해야 하는 작업을 수행할 때에 적절하게 롤백을 할 수 없을 것이다. 그래서 비즈니스 로직 내에 트랜잭션 경계 설정을 해주어야 한다. 하지만, 서비스 계층에 Connection을 들고 있을 수는 없다. 빈은 싱글톤으로 관리되기 때문에 상태를 가지면 여러 문제가 발생하게 된다.  
+![image](https://user-images.githubusercontent.com/45073750/121330915-650fcb80-c951-11eb-8ce6-f481356845e4.png)
+
+이를 위해 스프링에서는 트랜잭션 동기화라는 방식을 사용한다. 트랜잭션을 시작하기 위해 만든 Connection 오브젝트를 특별한 저장소에 보관해두고, 이후에 호출되는 DAO의 메서드에서는 저장된 Connection을 가져다가 사용하게 하는 방법이다. 정확히는 DAO가 사용하는 JdbcTemplate이 트랜잭션 동기화 방식을 이용하도록 하는 것이다.  
+![image](https://user-images.githubusercontent.com/45073750/121330995-748f1480-c951-11eb-9a0b-f241bdc06ded.png)
+
+하지만 만약 하나의 트랜잭션 안에서 여러 DB에 데이터를 넣게 되는 경우에 문제가 생긴다. 트랜잭션은 하나의 DB에 종속되기 때문이다. 이 경우에 글로벌 트랜잭션 방식을 사용해야 한다. 자바는 JDBC 외에 이런 글로벌 트랜잭션을 지원하는 트랜잭션 매니저를 지원하기 위한 API인 JTA(Java Transaction API)를 제공한다.  
+
+![image](https://user-images.githubusercontent.com/45073750/121335569-ac985680-c955-11eb-9790-29c5c76632da.png)
+
+하지만 이것을 사용하게되면 기술환경에 따라서 UserService의 코드를 변경해주어야 한다. 때에 따라서는 Hibernate를 사용할 수도 있는데 이 경우에는 Connection이 아닌 Session을 사용하게 되므로 이 경계 또한 설정해주어야 한다.  
+
+![image](https://user-images.githubusercontent.com/45073750/121349519-93e36d00-c964-11eb-882d-cea8962d34ca.png)
+
+Service에서는 이제 PlatformTransactionManager만 알면된다. DAO를 하이버네이트나 JPA, JDO 등을 사용하도록 수정하더라도 그에 맞게 transactionManager의 클래스만 변경해주면 되고, UserService는 변경할 필요가 없어지게 된다.  
+

--- a/src/main/java/domain/Level.java
+++ b/src/main/java/domain/Level.java
@@ -1,0 +1,17 @@
+package domain;
+
+public enum Level {
+    BASIC(1),
+    SILVER(2),
+    GOLD(3);
+
+    private final int value;
+
+    Level(int value) {
+        this.value = value;
+    }
+
+    public int intValue() {
+        return value;
+    }
+}

--- a/src/main/java/domain/User.java
+++ b/src/main/java/domain/User.java
@@ -1,9 +1,22 @@
 package domain;
 
 public class User {
+
     String id;
     String name;
     String password;
+    Level level;
+    int login;
+    int recommend;
+
+    public User(String id, String name, String password, Level level, int login, int recommend) {
+        this.id = id;
+        this.name = name;
+        this.password = password;
+        this.level = level;
+        this.login = login;
+        this.recommend = recommend;
+    }
 
     public String getId() {
         return id;
@@ -28,4 +41,29 @@ public class User {
     public void setPassword(String password) {
         this.password = password;
     }
+
+    public Level getLevel() {
+        return level;
+    }
+
+    public void setLevel(Level level) {
+        this.level = level;
+    }
+
+    public int getLogin() {
+        return login;
+    }
+
+    public void setLogin(int login) {
+        this.login = login;
+    }
+
+    public int getRecommend() {
+        return recommend;
+    }
+
+    public void setRecommend(int recommend) {
+        this.recommend = recommend;
+    }
+
 }

--- a/src/test/java/dao/UserDaoJdbcTest.java
+++ b/src/test/java/dao/UserDaoJdbcTest.java
@@ -1,6 +1,8 @@
 package dao;
 
+import domain.Level;
 import domain.User;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -14,51 +16,14 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class UserDaoJdbcTest {
 
-    @Test
-    @DisplayName("추가와 가지고오기")
-    public void addAndGet() throws SQLException {
-        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(DaoFactory.class);
-        UserDaoJdbc dao = context.getBean("userDaoJdbc", UserDaoJdbc.class);
-        User user = new User();
-        user.setId("asdf");
-        user.setName("asdf");
-        user.setPassword("asdf");
+    User user1;
+    User user2;
+    User user3;
 
-        dao.add(user);
-        User user2 = dao.get(user.getId());
-        assertThat(user2.getName()).isEqualTo(user.getName());
-        assertThat(user2.getPassword()).isEqualTo(user2.getPassword());
-
-        dao.deleteAll();
-        assertThat(dao.getCount()).isEqualTo(0);
-
-        User qwer = new User();
-        qwer.setId("qwer");
-        qwer.setName("qwer");
-        qwer.setPassword("qwer");
-
-        dao.add(qwer);
-        assertThat(dao.getCount()).isEqualTo(1);
-
-        User qwer2 = dao.get(qwer.getId());
-        assertThat(qwer2.getName()).isEqualTo(qwer.getName());
-        assertThat(qwer2.getPassword()).isEqualTo(qwer.getPassword());
-    }
-
-    @Test
-    @DisplayName("중복값 추가 확인")
-    public void duplicateData() {
-        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(DaoFactory.class);
-        UserDao dao = context.getBean("userDaoJdbc", UserDao.class);
-        User user = new User();
-        user.setId("kang");
-        user.setName("seung");
-        user.setPassword("yoon");
-
-        dao.deleteAll();
-        dao.add(user);
-
-        assertThatThrownBy(() -> dao.add(user))
-                .isInstanceOf(DataAccessException.class);
+    @BeforeEach
+    void setUp() {
+        this.user1 = new User("gyumee", "박성철", "springno1", Level.BASIC, 1, 0);
+        this.user2 = new User("leegw700", "이길원", "springno2", Level.SILVER, 55, 10);
+        this.user3 = new User("bumjin", "박범진", "springno3", Level.GOLD, 100, 40);
     }
 }


### PR DESCRIPTION
# 5. 서비스 추상화

JdbcTemplate은 하나의 템플릿 메소드 안에서 DataSource의 getConnection() 메소드를 호출해서 Connection 오브젝트를 가져오고, 작업을 마치면 Connection을 확실하게 닫아주고 템플릿 메소드를 빠져나온다.  

Dao 메소드를 호출할 때 마다 새로운 트랜잭션이 만들어지는 구도일 시에 여러번 DB 업데이트를 해야 하는 작업을 수행할 때에 적절하게 롤백을 할 수 없을 것이다. 그래서 비즈니스 로직 내에 트랜잭션 경계 설정을 해주어야 한다. 하지만, 서비스 계층에 Connection을 들고 있을 수는 없다. 빈은 싱글톤으로 관리되기 때문에 상태를 가지면 여러 문제가 발생하게 된다.  
![image](https://user-images.githubusercontent.com/45073750/121330915-650fcb80-c951-11eb-8ce6-f481356845e4.png)

이를 위해 스프링에서는 트랜잭션 동기화라는 방식을 사용한다. 트랜잭션을 시작하기 위해 만든 Connection 오브젝트를 특별한 저장소에 보관해두고, 이후에 호출되는 DAO의 메서드에서는 저장된 Connection을 가져다가 사용하게 하는 방법이다. 정확히는 DAO가 사용하는 JdbcTemplate이 트랜잭션 동기화 방식을 이용하도록 하는 것이다.  
![image](https://user-images.githubusercontent.com/45073750/121330995-748f1480-c951-11eb-9a0b-f241bdc06ded.png)

하지만 만약 하나의 트랜잭션 안에서 여러 DB에 데이터를 넣게 되는 경우에 문제가 생긴다. 트랜잭션은 하나의 DB에 종속되기 때문이다. 이 경우에 글로벌 트랜잭션 방식을 사용해야 한다. 자바는 JDBC 외에 이런 글로벌 트랜잭션을 지원하는 트랜잭션 매니저를 지원하기 위한 API인 JTA(Java Transaction API)를 제공한다.  

![image](https://user-images.githubusercontent.com/45073750/121335569-ac985680-c955-11eb-9790-29c5c76632da.png)

하지만 이것을 사용하게되면 기술환경에 따라서 UserService의 코드를 변경해주어야 한다. 때에 따라서는 Hibernate를 사용할 수도 있는데 이 경우에는 Connection이 아닌 Session을 사용하게 되므로 이 경계 또한 설정해주어야 한다.  

![image](https://user-images.githubusercontent.com/45073750/121349519-93e36d00-c964-11eb-882d-cea8962d34ca.png)

Service에서는 이제 PlatformTransactionManager만 알면된다. DAO를 하이버네이트나 JPA, JDO 등을 사용하도록 수정하더라도 그에 맞게 transactionManager의 클래스만 변경해주면 되고, UserService는 변경할 필요가 없어지게 된다.  


코드 안따라치고 그냥 읽었습니다!  
트랜잭션이 필요한 이유, 여러 디비를 사용할 경우의 글로벌 트랜잭션 이용과 그에 따른 추상화 계층 변환.  
커넥션이 아닌 다른 방식을 사용하는 경우(여러 다양한 기술)의 추상화 계층을 나누는 작업이 주된 내용이었네요. 메일은 안읽었습니다! 